### PR TITLE
Modify magazine publication button orientation

### DIFF
--- a/packages/refresh-theme/components/nodes/magazine-latest-issue.marko
+++ b/packages/refresh-theme/components/nodes/magazine-latest-issue.marko
@@ -24,9 +24,9 @@ $ const linkTitle = `${publication.name} ${issue.name}`;
       <marko-web-magazine-issue-name tag=null obj=issue link={ title: linkTitle } />
     </@title>
     <@footer>
-      <@left>
+      <@right>
         <default-theme-magazine-publication-buttons publication=publication issue=issue />
-      </@left>
+      </@right>
     </@footer>
   </@body>
 </marko-web-node>


### PR DESCRIPTION
`.node__footer-left` has a `max-width: 70%`, causing the buttons to stack on top of one another.

We can either adjust the css, or adjust the orientation from `left` to `right`.  Either way, the text is going to be centered regardless of which one is set, so neither orientation option really matters here, which is why I opted to go this route.

Otherwise, I can add a margin to .magazine-publication-buttons, leave them stacked, but space them out a bit so they’re not so clustered, but I think putting them all on the same line looks better, personally.  Open to suggestions!

![Screen Shot 2020-05-20 at 1 23 39 PM](https://user-images.githubusercontent.com/12496550/82484012-eb374680-9a9e-11ea-8833-7aea2022040d.png)

-----

## How they look on **prod:**

![image](https://user-images.githubusercontent.com/12496550/82483993-e4103880-9a9e-11ea-9ee0-92649781dcfc.png)
