### PR TITLE
Remove site restriction on company search box

### DIFF
--- a/packages/common/browser/algolia-company-search.vue
+++ b/packages/common/browser/algolia-company-search.vue
@@ -90,7 +90,7 @@ export default {
       phrase: '',
       disjunctiveFacetsRefinements: {
         type: ['Company'],
-        'websiteSchedules.siteIds': [this.siteId],
+        // 'websiteSchedules.siteIds': [this.siteId],
       },
     };
   },


### PR DESCRIPTION
At the moment there are only 329 of 17K+ companies scheduled to the site anywhere, so it was only returning those 329.  Removing this allows all published companies to be searched against.

<img width="1006" alt="Screen Shot 2021-03-11 at 8 25 21 AM" src="https://user-images.githubusercontent.com/3845869/110801942-56772280-8243-11eb-8b9f-44921a1834db.png">
