### PR TITLE
Update filters being applied for company search input

### DIFF
--- a/packages/common/browser/algolia-company-search.vue
+++ b/packages/common/browser/algolia-company-search.vue
@@ -6,7 +6,7 @@
     >
       <ais-configure
         :hits-per-page.camel="displayLimit"
-        :disjunctive-facets-refinements.camel="disjunctiveFacetsRefinements"
+        :filters="filters"
       />
       <ais-search-box
         v-model="phrase"
@@ -90,8 +90,8 @@ export default {
       phrase: '',
       disjunctiveFacetsRefinements: {
         type: ['Company'],
-        primarySiteId: [this.siteId],
       },
+      filters: `type:"Company" AND (primarySiteId:"${this.siteId}" OR 'websiteSchedules.siteIds':"${this.siteId}")`,
     };
   },
 


### PR DESCRIPTION
Apply where type:”Company” && (primarySiteId:”BLAH” OR 'websiteSchedules.siteIds’:”BLAH”)

In this case it has to be a company and have its primary site be the current site or be scheduled to the current site.