### PR TITLE
Update filters being applied to algolia company search box

### DIFF
--- a/packages/common/browser/algolia-company-search.vue
+++ b/packages/common/browser/algolia-company-search.vue
@@ -81,6 +81,12 @@ export default {
   },
 
   data() {
+    const filtersArray = [
+      'status = 1',
+      `published < ${Date.now()}`,
+      'type:"Company"',
+      `(primarySiteId:"${this.siteId}" OR 'websiteSchedules.siteIds':"${this.siteId}")`,
+    ];
     return {
       clickout: true,
       searchClient: algoliasearch(
@@ -88,7 +94,7 @@ export default {
         this.apiKey,
       ),
       phrase: '',
-      filters: `type:"Company" AND (primarySiteId:"${this.siteId}" OR 'websiteSchedules.siteIds':"${this.siteId}")`,
+      filters: filtersArray.join(' AND '),
     };
   },
 

--- a/packages/common/browser/algolia-company-search.vue
+++ b/packages/common/browser/algolia-company-search.vue
@@ -6,7 +6,7 @@
     >
       <ais-configure
         :hits-per-page.camel="displayLimit"
-        :disjunctive-facets-refinements.camel="disjunctiveFacetsRefinements"
+        :filters="filters"
       />
       <ais-search-box
         v-model="phrase"
@@ -90,8 +90,8 @@ export default {
       phrase: '',
       disjunctiveFacetsRefinements: {
         type: ['Company'],
-        primarySiteId: [this.siteId],
       },
+      filters: `type:"Company" AND (primarySiteId:"${this.siteId}" OR 'websiteSchedules.siteIds':"${this.siteId}")`,
     };
   },
 

--- a/packages/common/browser/algolia-company-search.vue
+++ b/packages/common/browser/algolia-company-search.vue
@@ -81,10 +81,11 @@ export default {
   },
 
   data() {
+    const now = Math.floor(new Date().getTime() / 1000);
     const filtersArray = [
       'status = 1',
-      `published < ${Date.now() / 1000}`,
-      `unpublished >= ${Date.now() / 1000}`,
+      `published < ${now}`,
+      `unpublished >= ${now}`,
       'type:"Company"',
       `(primarySiteId:"${this.siteId}" OR 'websiteSchedules.siteIds':"${this.siteId}")`,
     ];

--- a/packages/common/browser/algolia-company-search.vue
+++ b/packages/common/browser/algolia-company-search.vue
@@ -85,7 +85,7 @@ export default {
     const filtersArray = [
       'status = 1',
       `published < ${now}`,
-      `unpublished >= ${now}`,
+      `unpublished > ${now}`,
       'type:"Company"',
       `(primarySiteId:"${this.siteId}" OR 'websiteSchedules.siteIds':"${this.siteId}")`,
     ];

--- a/packages/common/browser/algolia-company-search.vue
+++ b/packages/common/browser/algolia-company-search.vue
@@ -88,9 +88,6 @@ export default {
         this.apiKey,
       ),
       phrase: '',
-      disjunctiveFacetsRefinements: {
-        type: ['Company'],
-      },
       filters: `type:"Company" AND (primarySiteId:"${this.siteId}" OR 'websiteSchedules.siteIds':"${this.siteId}")`,
     };
   },

--- a/packages/common/browser/algolia-company-search.vue
+++ b/packages/common/browser/algolia-company-search.vue
@@ -83,7 +83,8 @@ export default {
   data() {
     const filtersArray = [
       'status = 1',
-      `published < ${Date.now()}`,
+      `published < ${Date.now() / 1000}`,
+      `unpublished >= ${Date.now() / 1000}`,
       'type:"Company"',
       `(primarySiteId:"${this.siteId}" OR 'websiteSchedules.siteIds':"${this.siteId}")`,
     ];


### PR DESCRIPTION
Apply where filters 
```Javascript
const now = Math.floor(new Date().getTime() / 1000);
const filtersArray = [
  'status = 1',
  `published < ${now}`,
  `unpublished > ${now}`,
  'type:"Company"',
  `(primarySiteId:"${this.siteId}" OR 'websiteSchedules.siteIds':"${this.siteId}")`,
];
```
Than
```Javascript
filters: filtersArray.join(' AND '),
```
Turns into
`status = 1 AND published < 1615485251 AND unpublished > 1615485251 AND type:"Company" AND (primarySiteId:"53ca8d671784f8066eb2c949" OR 'websiteSchedules.siteIds':"53ca8d671784f8066eb2c949")`

In this case it has to be a company and have its primary site be the current site or be scheduled to the current site.