### PR TITLE
Remove sticky leaderboard from bottom of GIP

### DIFF
--- a/packages/refresh-theme/components/fixed-ad-bottom.marko
+++ b/packages/refresh-theme/components/fixed-ad-bottom.marko
@@ -1,7 +1,10 @@
 $ const { GAM } = out.global;
+$ const adUnit = GAM.getAdUnit({ name: "lb-sticky-bottom", aliases: input.aliases });
 
-<marko-web-gam-fixed-ad-bottom
-  ...GAM.getAdUnit({ name: "lb-sticky-bottom", aliases: input.aliases })
-  refresh-interval=15
-  scroll-offset=100
-/>
+<if(adUnit.path)>
+  <marko-web-gam-fixed-ad-bottom
+    ...adUnit
+    refresh-interval=15
+    scroll-offset=100
+  />
+</if>

--- a/sites/greenindustrypros.com/config/gam.js
+++ b/sites/greenindustrypros.com/config/gam.js
@@ -5,7 +5,6 @@ module.exports = {
       alias: 'default',
       map: {
         lb1: 'default/lb1',
-        'lb-sticky-bottom': 'default/lb1',
         rail1: 'default/rail1',
         rail2: 'default/rail1',
         'infinite-rail': 'default/rail1',
@@ -18,7 +17,6 @@ module.exports = {
       alias: 'mowing-maintenance',
       map: {
         lb1: 'mowing-maintenance/lb1',
-        'lb-sticky-bottom': 'mowing-maintenance/lb1',
         rail1: 'mowing-maintenance/rail1',
         rail2: 'mowing-maintenance/rail1',
         'infinite-rail': 'mowing-maintenance/rail1',
@@ -31,7 +29,6 @@ module.exports = {
       alias: 'lawn-care-renovation',
       map: {
         lb1: 'lawn-care-renovation/lb1',
-        'lb-sticky-bottom': 'lawn-care-renovation/lb1',
         rail1: 'lawn-care-renovation/rail1',
         rail2: 'lawn-care-renovation/rail1',
         'infinite-rail': 'lawn-care-renovation/rail1',
@@ -44,7 +41,6 @@ module.exports = {
       alias: 'design-installation',
       map: {
         lb1: 'design-installation/lb1',
-        'lb-sticky-bottom': 'design-installation/lb1',
         rail1: 'design-installation/rail1',
         rail2: 'design-installation/rail1',
         'infinite-rail': 'design-installation/rail1',
@@ -57,7 +53,6 @@ module.exports = {
       alias: 'irrigation-water-management',
       map: {
         lb1: 'irrigation-water-management/lb1',
-        'lb-sticky-bottom': 'irrigation-water-management/lb1',
         rail1: 'irrigation-water-management/rail1',
         rail2: 'irrigation-water-management/rail1',
         'infinite-rail': 'irrigation-water-management/rail1',
@@ -70,7 +65,6 @@ module.exports = {
       alias: 'snow-ice-management',
       map: {
         lb1: 'snow-ice-management/lb1',
-        'lb-sticky-bottom': 'snow-ice-management/lb1',
         rail1: 'snow-ice-management/rail1',
         rail2: 'snow-ice-management/rail1',
         'infinite-rail': 'snow-ice-management/rail1',


### PR DESCRIPTION
Lower sticky leaderboard ad no longer present. 
<img width="1791" alt="Screen Shot 2021-05-17 at 8 00 19 AM" src="https://user-images.githubusercontent.com/46794001/118492798-ffc81200-b6e5-11eb-9d71-35c8c07bccfd.png">
