### PR TITLE
Update the events page for SSO to look like FCP’s.

### DIFF
--- a/sites/safesecureopenings.com/server/routes/website-section.js
+++ b/sites/safesecureopenings.com/server/routes/website-section.js
@@ -3,6 +3,7 @@ const section = require('@ac-business-media/refresh-theme/templates/website-sect
 const podcasts = require('@ac-business-media/refresh-theme/templates/website-section/podcasts');
 const publishedVideos = require('@ac-business-media/refresh-theme/templates/website-section/published-videos');
 const contactUs = require('@ac-business-media/refresh-theme/templates/website-section/contact-us');
+const events = require('@ac-business-media/refresh-theme/templates/website-section/events');
 const queryFragment = require('@ac-business-media/refresh-theme/graphql/fragments/website-section-page');
 
 const directory = require('../templates/website-section/directory');
@@ -14,6 +15,10 @@ module.exports = (app) => {
   }));
   app.get('/:alias(contact-us)', withWebsiteSection({
     template: contactUs,
+    queryFragment,
+  }));
+  app.get('/:alias(events)', withWebsiteSection({
+    template: events,
     queryFragment,
   }));
   app.get('/:alias(podcasts)', withWebsiteSection({


### PR DESCRIPTION
New SSO Events Page:
<img width="1920" alt="Screen Shot 2021-07-08 at 9 43 51 AM" src="https://user-images.githubusercontent.com/46794001/124942510-501a6c80-dfd1-11eb-9e80-7f7c70d545bc.png">


FCP Events Page:
<img width="1920" alt="Screen Shot 2021-07-08 at 9 44 06 AM" src="https://user-images.githubusercontent.com/46794001/124942514-514b9980-dfd1-11eb-9e0b-dac335dcbf53.png">
