### PR TITLE
Enable sticky leaderboard on all sites within ACBM

### DIFF
--- a/packages/refresh-theme/gam/build-config.js
+++ b/packages/refresh-theme/gam/build-config.js
@@ -7,8 +7,10 @@ module.exports = ({
   basePath,
   pathMaps = [],
   stickyBottomTemplate = {
-    size: [[320, 50], [300, 50]],
+    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50]],
     sizeMapping: [
+      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
+      { viewport: [750, 0], size: [728, 90] },
       { viewport: [576, 0], size: [] },
       { viewport: [320, 0], size: [[300, 50], [320, 50]] },
     ],

--- a/sites/dmnews.com/config/gam.js
+++ b/sites/dmnews.com/config/gam.js
@@ -5,7 +5,7 @@ module.exports = {
       alias: 'default',
       map: {
         lb1: 'default/lb1',
-        'lb-sticky-bottom': 'default/lb1',
+        // 'lb-sticky-bottom': 'default/lb1',
         rail1: 'default/rail1',
         rail2: 'default/rail1',
         'infinite-rail': 'default/rail1',
@@ -18,7 +18,7 @@ module.exports = {
       alias: 'agencies',
       map: {
         lb1: 'agencies/lb1',
-        'lb-sticky-bottom': 'agencies/lb1',
+        // 'lb-sticky-bottom': 'agencies/lb1',
         rail1: 'agencies/rail1',
         rail2: 'agencies/rail1',
         'infinite-rail': 'agencies/rail1',
@@ -31,7 +31,7 @@ module.exports = {
       alias: 'marketing-channels',
       map: {
         lb1: 'marketing-channels/lb1',
-        'lb-sticky-bottom': 'marketing-channels/lb1',
+        // 'lb-sticky-bottom': 'marketing-channels/lb1',
         rail1: 'marketing-channels/rail1',
         rail2: 'marketing-channels/rail1',
         'infinite-rail': 'marketing-channels/rail1',
@@ -44,7 +44,7 @@ module.exports = {
       alias: 'content-marketing',
       map: {
         lb1: 'content-marketing/lb1',
-        'lb-sticky-bottom': 'content-marketing/lb1',
+        // 'lb-sticky-bottom': 'content-marketing/lb1',
         rail1: 'content-marketing/rail1',
         rail2: 'content-marketing/rail1',
         'infinite-rail': 'content-marketing/rail1',
@@ -57,7 +57,7 @@ module.exports = {
       alias: 'customer-experience',
       map: {
         lb1: 'customer-experience/lb1',
-        'lb-sticky-bottom': 'customer-experience/lb1',
+        // 'lb-sticky-bottom': 'customer-experience/lb1',
         rail1: 'customer-experience/rail1',
         rail2: 'customer-experience/rail1',
         'infinite-rail': 'customer-experience/rail1',
@@ -70,7 +70,7 @@ module.exports = {
       alias: 'data',
       map: {
         lb1: 'data/lb1',
-        'lb-sticky-bottom': 'data/lb1',
+        // 'lb-sticky-bottom': 'data/lb1',
         rail1: 'data/rail1',
         rail2: 'data/rail1',
         'infinite-rail': 'data/rail1',
@@ -83,7 +83,7 @@ module.exports = {
       alias: 'retail',
       map: {
         lb1: 'retail/lb1',
-        'lb-sticky-bottom': 'retail/lb1',
+        // 'lb-sticky-bottom': 'retail/lb1',
         rail1: 'retail/rail1',
         rail2: 'retail/rail1',
         'infinite-rail': 'retail/rail1',

--- a/sites/forconstructionpros.com/config/gam.js
+++ b/sites/forconstructionpros.com/config/gam.js
@@ -5,7 +5,7 @@ module.exports = {
       alias: 'default',
       map: {
         lb1: 'default/lb1',
-        'lb-sticky-bottom': 'default/lb1',
+        // 'lb-sticky-bottom': 'default/lb1',
         rail1: 'default/rail1',
         rail2: 'default/rail1',
         'infinite-rail': 'default/rail1',
@@ -18,7 +18,7 @@ module.exports = {
       alias: 'equipment',
       map: {
         lb1: 'equipment/lb1',
-        'lb-sticky-bottom': 'equipment/lb1',
+        // 'lb-sticky-bottom': 'equipment/lb1',
         rail1: 'equipment/rail1',
         rail2: 'equipment/rail1',
         'infinite-rail': 'equipment/rail1',
@@ -31,7 +31,7 @@ module.exports = {
       alias: 'equipment/compaction',
       map: {
         lb1: 'equipment/compaction/lb1',
-        'lb-sticky-bottom': 'equipment/compaction/lb1',
+        // 'lb-sticky-bottom': 'equipment/compaction/lb1',
         rail1: 'equipment/compaction/rail1',
         rail2: 'equipment/compaction/rail1',
         'infinite-rail': 'equipment/compaction/rail1',
@@ -44,7 +44,7 @@ module.exports = {
       alias: 'equipment/earthmoving-compact',
       map: {
         lb1: 'equipment/earthmoving-compact/lb1',
-        'lb-sticky-bottom': 'equipment/earthmoving-compact/lb1',
+        // 'lb-sticky-bottom': 'equipment/earthmoving-compact/lb1',
         rail1: 'equipment/earthmoving-compact/rail1',
         rail2: 'equipment/earthmoving-compact/rail1',
         'infinite-rail': 'equipment/earthmoving-compact/rail1',
@@ -57,7 +57,7 @@ module.exports = {
       alias: 'equipment/earthmoving',
       map: {
         lb1: 'equipment/earthmoving/lb1',
-        'lb-sticky-bottom': 'equipment/earthmoving/lb1',
+        // 'lb-sticky-bottom': 'equipment/earthmoving/lb1',
         rail1: 'equipment/earthmoving/rail1',
         rail2: 'equipment/earthmoving/rail1',
         'infinite-rail': 'equipment/earthmoving/rail1',
@@ -70,7 +70,7 @@ module.exports = {
       alias: 'equipment/fleet-maintenance',
       map: {
         lb1: 'equipment/fleet-maintenance/lb1',
-        'lb-sticky-bottom': 'equipment/fleet-maintenance/lb1',
+        // 'lb-sticky-bottom': 'equipment/fleet-maintenance/lb1',
         rail1: 'equipment/fleet-maintenance/rail1',
         rail2: 'equipment/fleet-maintenance/rail1',
         'infinite-rail': 'equipment/fleet-maintenance/rail1',
@@ -83,7 +83,7 @@ module.exports = {
       alias: 'trucks',
       map: {
         lb1: 'trucks/lb1',
-        'lb-sticky-bottom': 'trucks/lb1',
+        // 'lb-sticky-bottom': 'trucks/lb1',
         rail1: 'trucks/rail1',
         rail2: 'trucks/rail1',
         'infinite-rail': 'trucks/rail1',
@@ -96,7 +96,7 @@ module.exports = {
       alias: 'rental',
       map: {
         lb1: 'rental/lb1',
-        'lb-sticky-bottom': 'rental/lb1',
+        // 'lb-sticky-bottom': 'rental/lb1',
         rail1: 'rental/rail1',
         rail2: 'rental/rail1',
         'infinite-rail': 'rental/rail1',
@@ -109,7 +109,7 @@ module.exports = {
       alias: 'rental/lifting-equipment',
       map: {
         lb1: 'rental/lifting-equipment/lb1',
-        'lb-sticky-bottom': 'rental/lb1',
+        // 'lb-sticky-bottom': 'rental/lb1',
         rail1: 'rental/lifting-equipment/rail1',
         rail2: 'rental/lifting-equipment/rail1',
         'infinite-rail': 'rental/lifting-equipment/rail1',
@@ -122,7 +122,7 @@ module.exports = {
       alias: 'concrete',
       map: {
         lb1: 'concrete/lb1',
-        'lb-sticky-bottom': 'concrete/lb1',
+        // 'lb-sticky-bottom': 'concrete/lb1',
         rail1: 'concrete/rail1',
         rail2: 'concrete/rail1',
         'infinite-rail': 'concrete/rail1',
@@ -135,7 +135,7 @@ module.exports = {
       alias: 'asphalt',
       map: {
         lb1: 'asphalt/lb1',
-        'lb-sticky-bottom': 'asphalt/lb1',
+        // 'lb-sticky-bottom': 'asphalt/lb1',
         rail1: 'asphalt/rail1',
         rail2: 'asphalt/rail1',
         'infinite-rail': 'asphalt/rail1',
@@ -148,7 +148,7 @@ module.exports = {
       alias: 'pavement-maintenance',
       map: {
         lb1: 'pavement-maintenance/lb1',
-        'lb-sticky-bottom': 'pavement-maintenance/lb1',
+        // 'lb-sticky-bottom': 'pavement-maintenance/lb1',
         rail1: 'pavement-maintenance/rail1',
         rail2: 'pavement-maintenance/rail1',
         'infinite-rail': 'pavement-maintenance/rail1',
@@ -161,7 +161,7 @@ module.exports = {
       alias: 'pavement-maintenance/preservation-maintenance',
       map: {
         lb1: 'pavement-maintenance/preservation-maintenance/lb1',
-        'lb-sticky-bottom': 'pavement-maintenance/preservation-maintenance/lb1',
+        // 'lb-sticky-bottom': 'pavement-maintenance/preservation-maintenance/lb1',
         rail1: 'pavement-maintenance/preservation-maintenance/rail1',
         rail2: 'pavement-maintenance/preservation-maintenance/rail1',
         'infinite-rail': 'pavement-maintenance/preservation-maintenance/rail1',
@@ -174,7 +174,7 @@ module.exports = {
       alias: 'equipment-management',
       map: {
         lb1: 'equipment-management/lb1',
-        'lb-sticky-bottom': 'equipment-management/lb1',
+        // 'lb-sticky-bottom': 'equipment-management/lb1',
         rail1: 'equipment-management/rail1',
         rail2: 'equipment-management/rail1',
         'infinite-rail': 'equipment-management/rail1',
@@ -187,7 +187,7 @@ module.exports = {
       alias: 'construction-technology',
       map: {
         lb1: 'construction-technology/lb1',
-        'lb-sticky-bottom': 'construction-technology/lb1',
+        // 'lb-sticky-bottom': 'construction-technology/lb1',
         rail1: 'construction-technology/rail1',
         rail2: 'construction-technology/rail1',
         'infinite-rail': 'construction-technology/rail1',
@@ -200,7 +200,7 @@ module.exports = {
       alias: 'business',
       map: {
         lb1: 'business/lb1',
-        'lb-sticky-bottom': 'business/lb1',
+        // 'lb-sticky-bottom': 'business/lb1',
         rail1: 'business/rail1',
         rail2: 'business/rail1',
         'infinite-rail': 'business/rail1',
@@ -213,7 +213,7 @@ module.exports = {
       alias: 'conexpo',
       map: {
         lb1: 'conexpo/lb1',
-        'lb-sticky-bottom': 'conexpo/lb1',
+        // 'lb-sticky-bottom': 'conexpo/lb1',
         rail1: 'conexpo/rail1',
         rail2: 'conexpo/rail1',
         'infinite-rail': 'conexpo/rail1',
@@ -226,7 +226,7 @@ module.exports = {
       alias: 'profit-matters',
       map: {
         lb1: 'profit-matters/lb1',
-        'lb-sticky-bottom': 'profit-matters/lb1',
+        // 'lb-sticky-bottom': 'profit-matters/lb1',
         rail1: 'profit-matters/rail1',
         rail2: 'profit-matters/rail1',
         'infinite-rail': 'profit-matters/rail1',

--- a/sites/greenindustrypros.com/config/gam.js
+++ b/sites/greenindustrypros.com/config/gam.js
@@ -5,6 +5,7 @@ module.exports = {
       alias: 'default',
       map: {
         lb1: 'default/lb1',
+        // 'lb-sticky-bottom': 'default/lb1',
         rail1: 'default/rail1',
         rail2: 'default/rail1',
         'infinite-rail': 'default/rail1',
@@ -17,6 +18,7 @@ module.exports = {
       alias: 'mowing-maintenance',
       map: {
         lb1: 'mowing-maintenance/lb1',
+        // 'lb-sticky-bottom': 'mowing-maintenance/lb1',
         rail1: 'mowing-maintenance/rail1',
         rail2: 'mowing-maintenance/rail1',
         'infinite-rail': 'mowing-maintenance/rail1',
@@ -29,6 +31,7 @@ module.exports = {
       alias: 'lawn-care-renovation',
       map: {
         lb1: 'lawn-care-renovation/lb1',
+        // 'lb-sticky-bottom': 'lawn-care-renovation/lb1',
         rail1: 'lawn-care-renovation/rail1',
         rail2: 'lawn-care-renovation/rail1',
         'infinite-rail': 'lawn-care-renovation/rail1',
@@ -41,6 +44,7 @@ module.exports = {
       alias: 'design-installation',
       map: {
         lb1: 'design-installation/lb1',
+        // 'lb-sticky-bottom': 'design-installation/lb1',
         rail1: 'design-installation/rail1',
         rail2: 'design-installation/rail1',
         'infinite-rail': 'design-installation/rail1',
@@ -53,6 +57,7 @@ module.exports = {
       alias: 'irrigation-water-management',
       map: {
         lb1: 'irrigation-water-management/lb1',
+        // 'lb-sticky-bottom': 'irrigation-water-management/lb1',
         rail1: 'irrigation-water-management/rail1',
         rail2: 'irrigation-water-management/rail1',
         'infinite-rail': 'irrigation-water-management/rail1',
@@ -65,6 +70,7 @@ module.exports = {
       alias: 'snow-ice-management',
       map: {
         lb1: 'snow-ice-management/lb1',
+        // 'lb-sticky-bottom': 'snow-ice-management/lb1',
         rail1: 'snow-ice-management/rail1',
         rail2: 'snow-ice-management/rail1',
         'infinite-rail': 'snow-ice-management/rail1',

--- a/sites/greenindustrypros.com/config/gam.js
+++ b/sites/greenindustrypros.com/config/gam.js
@@ -74,12 +74,4 @@ module.exports = {
       },
     },
   ],
-  stickyBottomTemplate: {
-    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50]],
-    sizeMapping: [
-      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
-      { viewport: [750, 0], size: [728, 90] },
-      { viewport: [320, 0], size: [[300, 50], [320, 50]] },
-    ],
-  },
 };

--- a/sites/oemoffhighway.com/config/gam.js
+++ b/sites/oemoffhighway.com/config/gam.js
@@ -5,7 +5,7 @@ module.exports = {
       alias: 'default',
       map: {
         lb1: 'default/lb1',
-        'lb-sticky-bottom': 'default/lb1',
+        // 'lb-sticky-bottom': 'default/lb1',
         rail1: 'default/rail1',
         rail2: 'default/rail1',
         'infinite-rail': 'default/rail1',
@@ -18,7 +18,7 @@ module.exports = {
       alias: 'engines',
       map: {
         lb1: 'engines/lb1',
-        'lb-sticky-bottom': 'engines/lb1',
+        // 'lb-sticky-bottom': 'engines/lb1',
         rail1: 'engines/rail1',
         rail2: 'engines/rail1',
         'infinite-rail': 'engines/rail1',
@@ -31,7 +31,7 @@ module.exports = {
       alias: 'drivetrains',
       map: {
         lb1: 'drivetrains/lb1',
-        'lb-sticky-bottom': 'drivetrains/lb1',
+        // 'lb-sticky-bottom': 'drivetrains/lb1',
         rail1: 'drivetrains/rail1',
         rail2: 'drivetrains/rail1',
         'infinite-rail': 'drivetrains/rail1',
@@ -44,7 +44,7 @@ module.exports = {
       alias: 'fluid-power',
       map: {
         lb1: 'fluid-power/lb1',
-        'lb-sticky-bottom': 'fluid-power/lb1',
+        // 'lb-sticky-bottom': 'fluid-power/lb1',
         rail1: 'fluid-power/rail1',
         rail2: 'fluid-power/rail1',
         'infinite-rail': 'fluid-power/rail1',
@@ -57,7 +57,7 @@ module.exports = {
       alias: 'electronics',
       map: {
         lb1: 'electronics/lb1',
-        'lb-sticky-bottom': 'electronics/lb1',
+        // 'lb-sticky-bottom': 'electronics/lb1',
         rail1: 'electronics/rail1',
         rail2: 'electronics/rail1',
         'infinite-rail': 'electronics/rail1',
@@ -70,7 +70,7 @@ module.exports = {
       alias: 'operator-cab',
       map: {
         lb1: 'operator-cab/lb1',
-        'lb-sticky-bottom': 'operator-cab/lb1',
+        // 'lb-sticky-bottom': 'operator-cab/lb1',
         rail1: 'operator-cab/rail1',
         rail2: 'operator-cab/rail1',
         'infinite-rail': 'operator-cab/rail1',
@@ -83,7 +83,7 @@ module.exports = {
       alias: 'engineering-manufacturing',
       map: {
         lb1: 'engineering-manufacturing/lb1',
-        'lb-sticky-bottom': 'engineering-manufacturing/lb1',
+        // 'lb-sticky-bottom': 'engineering-manufacturing/lb1',
         rail1: 'engineering-manufacturing/rail1',
         rail2: 'engineering-manufacturing/rail1',
         'infinite-rail': 'engineering-manufacturing/rail1',
@@ -96,7 +96,7 @@ module.exports = {
       alias: 'ifpe-conexpo',
       map: {
         lb1: 'ifpe-conexpo/lb1',
-        'lb-sticky-bottom': 'ifpe-conexpo/lb1',
+        // 'lb-sticky-bottom': 'ifpe-conexpo/lb1',
         rail1: 'ifpe-conexpo/rail1',
         rail2: 'ifpe-conexpo/rail1',
         'infinite-rail': 'ifpe-conexpo/rail1',

--- a/sites/safesecureopenings.com/config/gam.js
+++ b/sites/safesecureopenings.com/config/gam.js
@@ -5,7 +5,7 @@ module.exports = {
       alias: 'default',
       map: {
         lb1: 'default/lb1',
-        'lb-sticky-bottom': 'default/lb1',
+        // 'lb-sticky-bottom': 'default/lb1',
         rail1: 'default/rail1',
         rail2: 'default/rail1',
         'infinite-rail': 'default/rail1',
@@ -18,7 +18,7 @@ module.exports = {
       alias: 'business',
       map: {
         lb1: 'business/lb1',
-        'lb-sticky-bottom': 'business/lb1',
+        // 'lb-sticky-bottom': 'business/lb1',
         rail1: 'business/rail1',
         rail2: 'business/rail1',
         'infinite-rail': 'business/rail1',
@@ -31,7 +31,7 @@ module.exports = {
       alias: 'access-control',
       map: {
         lb1: 'access-control/lb1',
-        'lb-sticky-bottom': 'access-control/lb1',
+        // 'lb-sticky-bottom': 'access-control/lb1',
         rail1: 'access-control/rail1',
         rail2: 'access-control/rail1',
         'infinite-rail': 'access-control/rail1',
@@ -44,7 +44,7 @@ module.exports = {
       alias: 'codes-standards',
       map: {
         lb1: 'codes-standards/lb1',
-        'lb-sticky-bottom': 'codes-standards/lb1',
+        // 'lb-sticky-bottom': 'codes-standards/lb1',
         rail1: 'codes-standards/rail1',
         rail2: 'codes-standards/rail1',
         'infinite-rail': 'codes-standards/rail1',
@@ -57,7 +57,7 @@ module.exports = {
       alias: 'construction-design',
       map: {
         lb1: 'construction-design/lb1',
-        'lb-sticky-bottom': 'construction-design/lb1',
+        // 'lb-sticky-bottom': 'construction-design/lb1',
         rail1: 'construction-design/rail1',
         rail2: 'construction-design/rail1',
         'infinite-rail': 'construction-design/rail1',
@@ -70,7 +70,7 @@ module.exports = {
       alias: 'healthcare',
       map: {
         lb1: 'healthcare/lb1',
-        'lb-sticky-bottom': 'healthcare/lb1',
+        // 'lb-sticky-bottom': 'healthcare/lb1',
         rail1: 'healthcare/rail1',
         rail2: 'healthcare/rail1',
         'infinite-rail': 'healthcare/rail1',
@@ -83,7 +83,7 @@ module.exports = {
       alias: 'security-safety',
       map: {
         lb1: 'security-safety/lb1',
-        'lb-sticky-bottom': 'security-safety/lb1',
+        // 'lb-sticky-bottom': 'security-safety/lb1',
         rail1: 'security-safety/rail1',
         rail2: 'security-safety/rail1',
         'infinite-rail': 'security-safety/rail1',
@@ -96,7 +96,7 @@ module.exports = {
       alias: 'sustainability',
       map: {
         lb1: 'sustainability/lb1',
-        'lb-sticky-bottom': 'sustainability/lb1',
+        // 'lb-sticky-bottom': 'sustainability/lb1',
         rail1: 'sustainability/rail1',
         rail2: 'sustainability/rail1',
         'infinite-rail': 'sustainability/rail1',


### PR DESCRIPTION
This alongside the change made to fixed-ad-bottom.marko here: https://github.com/parameter1/ac-business-media-websites/pull/299 should now allow for if an ad can be found for the sticky bottom leaderboard alias placement it will place it.