### PR TITLE
Add MINExpo 2021 channel to primary nav on OEM.

### DIFF
--- a/sites/oemoffhighway.com/config/navigation.js
+++ b/sites/oemoffhighway.com/config/navigation.js
@@ -7,6 +7,7 @@ module.exports = {
       { href: '/electronics', label: 'Electronics' },
       { href: '/operator-cab', label: 'Operator Cab' },
       { href: '/engineering-manufacturing', label: 'Engineering & Manufacturing' },
+      { href: '/minexpo-2021', label: 'MINExpo 2021' },
     ],
   },
   secondary: {


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-08-02 at 8 13 38 AM" src="https://user-images.githubusercontent.com/46794001/127867817-2511a500-5bd8-4774-a72e-d5a66a335f17.png">
<img width="1920" alt="Screen Shot 2021-08-02 at 8 13 46 AM" src="https://user-images.githubusercontent.com/46794001/127867824-53cac032-c6f3-4f08-8d18-79e3b537b4d0.png">
