### PR TITLE
Update spec guides to use new google docs v4 api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ x-env-defaults: &env
   # @todo the recaptcha values should be removed (?) once contact-us is moved to core.
   RECAPTCHA_SITE_KEY: ${RECAPTCHA_SITE_KEY-(unset)}
   RECAPTCHA_SECRET_KEY: ${RECAPTCHA_SECRET_KEY-(unset)}
+  GOOGLE_DOC_API_KEY: ${GOOGLE_DOC_API_KEY-(unset)}
   # @todo the sendgrid values should be removed once the @parameter1/base-cms-mailer service is created.
   SENDGRID_API_KEY: ${SENDGRID_API_KEY-(unset)}
   SENDGRID_DEV_TO: contact@parameter1.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ x-env-defaults: &env
   # @todo the recaptcha values should be removed (?) once contact-us is moved to core.
   RECAPTCHA_SITE_KEY: ${RECAPTCHA_SITE_KEY-(unset)}
   RECAPTCHA_SECRET_KEY: ${RECAPTCHA_SECRET_KEY-(unset)}
-  GOOGLE_DOC_API_KEY: ${GOOGLE_DOC_API_KEY-(unset)}
+  SPEC_GUIDE_DOCS_API_KEY: ${SPEC_GUIDE_DOCS_API_KEY-(unset)}
   # @todo the sendgrid values should be removed once the @parameter1/base-cms-mailer service is created.
   SENDGRID_API_KEY: ${SENDGRID_API_KEY-(unset)}
   SENDGRID_DEV_TO: contact@parameter1.com

--- a/packages/common/browser/spec-guide/table.vue
+++ b/packages/common/browser/spec-guide/table.vue
@@ -392,7 +392,7 @@ export default {
       try {
         const { sheetSrc } = this;
         if (!sheetSrc) throw new Error('No data source was provided.');
-        const res = await fetch(sheetSrc);
+        const res = await fetch(`/__spec-guide?src=${encodeURIComponent(sheetSrc)}`);
         if (!res.ok) throw new Error('Network error encountered when retrieving data.');
         const json = await res.json();
 

--- a/packages/common/browser/spec-guide/table.vue
+++ b/packages/common/browser/spec-guide/table.vue
@@ -396,7 +396,8 @@ export default {
         if (!res.ok) throw new Error('Network error encountered when retrieving data.');
         const json = await res.json();
 
-        // Added google API v4 from v3 support to have set data from unkeyed rows to keyed rows by column header
+        // Added google API v4 from v3 support to have set data
+        // from unkeyed rows to keyed rows by column header
         const unKeyed = get(json, 'values');
         const sheetKeys = unKeyed.shift().map(v => v.toLowerCase().replace(/\s+|[,()/]/g, ''));
         let rows = unKeyed.map((row) => {

--- a/packages/common/browser/spec-guide/table.vue
+++ b/packages/common/browser/spec-guide/table.vue
@@ -400,13 +400,10 @@ export default {
         // from unkeyed rows to keyed rows by column header
         const unKeyed = get(json, 'values');
         const sheetKeys = unKeyed.shift().map(v => v.toLowerCase().replace(/\s+|[,()/]/g, ''));
-        let rows = unKeyed.map((row) => {
-          const keyedRow = {};
-          sheetKeys.forEach((key, index) => {
-            keyedRow[key] = row[index];
-          });
-          return keyedRow;
-        });
+        let rows = unKeyed.map(row => sheetKeys.reduce((obj, key, index) => ({
+          ...obj,
+          [key]: row[index],
+        }), {}));
 
         // Format/simplify the raw data.
         this.rows = isArray(rows) ? rows.map((row) => {

--- a/packages/common/browser/spec-guide/table.vue
+++ b/packages/common/browser/spec-guide/table.vue
@@ -379,7 +379,7 @@ export default {
     },
 
     getSourceValue(row, key) {
-      return get(row, `gsx$${key}.$t`);
+      return get(row, key);
     },
 
     /**
@@ -395,7 +395,17 @@ export default {
         const res = await fetch(sheetSrc);
         if (!res.ok) throw new Error('Network error encountered when retrieving data.');
         const json = await res.json();
-        let rows = get(json, 'feed.entry');
+
+        // Added google API v4 from v3 support to have set data from unkeyed rows to keyed rows by column header
+        const unKeyed = get(json, 'values');
+        const sheetKeys = unKeyed.shift().map(v => v.toLowerCase().replace(/\s+|[,()/]/g, ''));
+        let rows = unKeyed.map((row) => {
+          const keyedRow = {};
+          sheetKeys.forEach((key, index) => {
+            keyedRow[key] = row[index];
+          });
+          return keyedRow;
+        });
 
         // Format/simplify the raw data.
         this.rows = isArray(rows) ? rows.map((row) => {

--- a/packages/common/env.js
+++ b/packages/common/env.js
@@ -5,7 +5,7 @@ const { nonemptystr } = validators;
 // @todo This should be removed once contact us is moved to core and the mailer service is created.
 module.exports = cleanEnv(process.env, {
   RECAPTCHA_SECRET_KEY: nonemptystr({ desc: 'The Recaptcha secret key.' }),
-  GOOGLE_DOC_API_KEY: nonemptystr({ desc: 'The google doc api secret key.' }),
+  SPEC_GUIDE_DOCS_API_KEY: nonemptystr({ desc: 'The google doc api secret key.' }),
   SENDGRID_API_KEY: nonemptystr({ desc: 'An API key for sending email via SendGrid.' }),
   SENDGRID_DEV_TO: email({ desc: 'In non-production environments, where emails should be sent.', default: 'contact@parameter1.com' }),
 });

--- a/packages/common/env.js
+++ b/packages/common/env.js
@@ -5,6 +5,7 @@ const { nonemptystr } = validators;
 // @todo This should be removed once contact us is moved to core and the mailer service is created.
 module.exports = cleanEnv(process.env, {
   RECAPTCHA_SECRET_KEY: nonemptystr({ desc: 'The Recaptcha secret key.' }),
+  GOOGLE_DOC_API_KEY: nonemptystr({ desc: 'The google doc api secret key.' }),
   SENDGRID_API_KEY: nonemptystr({ desc: 'An API key for sending email via SendGrid.' }),
   SENDGRID_DEV_TO: email({ desc: 'In non-production environments, where emails should be sent.', default: 'contact@parameter1.com' }),
 });

--- a/packages/common/spec-guide/index.js
+++ b/packages/common/spec-guide/index.js
@@ -1,11 +1,11 @@
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const fetch = require('node-fetch');
 
-const { GOOGLE_DOC_API_KEY } = process.env;
+const { SPEC_GUIDE_DOCS_API_KEY } = process.env;
 module.exports = (app) => {
   app.use('/__spec-guide', asyncRoute(async (req, res) => {
     const { src } = req.query;
-    const url = `${src}?key=${GOOGLE_DOC_API_KEY}`;
+    const url = `${src}?key=${SPEC_GUIDE_DOCS_API_KEY}`;
     try {
       const response = await fetch(url);
       const json = await response.json();

--- a/packages/common/spec-guide/index.js
+++ b/packages/common/spec-guide/index.js
@@ -1,0 +1,17 @@
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const fetch = require('node-fetch');
+
+const { GOOGLE_DOC_API_KEY } = process.env;
+module.exports = (app) => {
+  app.use('/__spec-guide', asyncRoute(async (req, res) => {
+    const { src } = req.query;
+    const url = `${src}?key=${GOOGLE_DOC_API_KEY}`;
+    try {
+      const response = await fetch(url);
+      const json = await response.json();
+      res.send(json);
+    } catch (error) {
+      res.send(error);
+    }
+  }));
+};

--- a/packages/common/spec-guide/index.js
+++ b/packages/common/spec-guide/index.js
@@ -11,7 +11,7 @@ module.exports = (app) => {
       const json = await response.json();
       res.send(json);
     } catch (error) {
-      res.send(error);
+      res.status(500).send(error);
     }
   }));
 };

--- a/packages/common/spec-guide/index.js
+++ b/packages/common/spec-guide/index.js
@@ -1,7 +1,7 @@
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const fetch = require('node-fetch');
+const { SPEC_GUIDE_DOCS_API_KEY } = require('../env');
 
-const { SPEC_GUIDE_DOCS_API_KEY } = process.env;
 module.exports = (app) => {
   app.use('/__spec-guide', asyncRoute(async (req, res) => {
     const { src } = req.query;

--- a/packages/refresh-theme/start-server.js
+++ b/packages/refresh-theme/start-server.js
@@ -4,6 +4,7 @@ const { startServer } = require('@parameter1/base-cms-marko-web');
 const { set, get, getAsObject } = require('@parameter1/base-cms-object-path');
 const cleanResponse = require('@parameter1/base-cms-marko-core/middleware/clean-marko-response');
 const contactUsHandler = require('@ac-business-media/package-common/contact-us');
+const specGuideHandler = require('@ac-business-media/package-common/spec-guide');
 const loadInquiry = require('@parameter1/base-cms-marko-web-inquiry');
 const omedaGraphQL = require('@parameter1/omeda-graphql-client-express');
 
@@ -22,6 +23,8 @@ const routes = siteRoutes => (app) => {
   loadInquiry(app);
   // Handle contact submissions on /__contact-us
   contactUsHandler(app);
+  // Handle spec-guide sheet request on /__spec-guide?src=${sheetSrc}
+  specGuideHandler(app);
   // Load site routes.
   siteRoutes(app);
 };

--- a/sites/forconstructionpros.com/config/spec-guides/asphalt-paver.js
+++ b/sites/forconstructionpros.com/config/spec-guides/asphalt-paver.js
@@ -10,7 +10,7 @@ module.exports = {
     src: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/asphalt-paver.jpg',
   },
   downloadLink: '/21036185',
-  sheetSrc: 'https://spreadsheets.google.com/feeds/list/1Lx2srmVT5OTFf9y1TZjpCRnYFGWNlDp7J_eDzznuL8M/1/public/values?alt=json',
+  sheetSrc: 'https://content-sheets.googleapis.com/v4/spreadsheets/1Lx2srmVT5OTFf9y1TZjpCRnYFGWNlDp7J_eDzznuL8M/values/Sheet1',
   columns: {
     manufacturer: {
       label: 'Manufacturer',

--- a/sites/forconstructionpros.com/config/spec-guides/backhoe-loader.js
+++ b/sites/forconstructionpros.com/config/spec-guides/backhoe-loader.js
@@ -12,7 +12,7 @@ module.exports = {
     src: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/backhoe.png',
   },
   downloadLink: '/21036185',
-  sheetSrc: 'https://spreadsheets.google.com/feeds/list/1ylNVqjRuvRu9_JUgyOuWSPXeGn6FkIw7McjFdZzdv0M/1/public/values?alt=json',
+  sheetSrc: 'https://content-sheets.googleapis.com/v4/spreadsheets/1ylNVqjRuvRu9_JUgyOuWSPXeGn6FkIw7McjFdZzdv0M/values/Backhoe-2019',
   columns: {
     company: {
       label: 'Company',

--- a/sites/forconstructionpros.com/config/spec-guides/excavator.js
+++ b/sites/forconstructionpros.com/config/spec-guides/excavator.js
@@ -12,7 +12,7 @@ module.exports = {
     src: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/excavator.jpg',
   },
   downloadLink: '/21009138',
-  sheetSrc: 'https://spreadsheets.google.com/feeds/list/1LYU3btf5iNzaBdONjMvZmK7KiEDxSUofUR6fvJGxU2Q/1/public/values?alt=json',
+  sheetSrc: 'https://content-sheets.googleapis.com/v4/spreadsheets/1LYU3btf5iNzaBdONjMvZmK7KiEDxSUofUR6fvJGxU2Q/values/Excavator-2016',
   columns: {
     company: {
       label: 'Company',

--- a/sites/forconstructionpros.com/config/spec-guides/roller.js
+++ b/sites/forconstructionpros.com/config/spec-guides/roller.js
@@ -20,7 +20,7 @@ module.exports = {
     src: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/tandem-roller.jpg',
   },
   downloadLink: '/20973242',
-  sheetSrc: 'https://spreadsheets.google.com/feeds/list/1BtttRyP7IT3IkpYZ7_paT3o_LJhtijyRBmODO0V2I9I/1/public/values?alt=json',
+  sheetSrc: 'https://content-sheets.googleapis.com/v4/spreadsheets/1BtttRyP7IT3IkpYZ7_paT3o_LJhtijyRBmODO0V2I9I/values/Sheet1',
   columns: {
     manufacturer: {
       label: 'Manufacturer',

--- a/sites/forconstructionpros.com/config/spec-guides/skid-steer.js
+++ b/sites/forconstructionpros.com/config/spec-guides/skid-steer.js
@@ -12,8 +12,7 @@ module.exports = {
     src: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/skidsteerlarge.jpg',
   },
   downloadLink: '/21563130',
-  sheetSrc: 'https://spreadsheets.google.com/feeds/list/12TC912nI227058ho8_zrLwYYzp7P2T7zZDCXO0ZTSZw/1/public/values?alt=json',
-
+  sheetSrc: 'https://content-sheets.googleapis.com/v4/spreadsheets/12TC912nI227058ho8_zrLwYYzp7P2T7zZDCXO0ZTSZw/values/Sheet1',
   columns: {
     manufacturer: {
       label: 'Manufacturer',

--- a/sites/oemoffhighway.com/config/spec-guides/engine.js
+++ b/sites/oemoffhighway.com/config/spec-guides/engine.js
@@ -10,7 +10,7 @@ module.exports = {
     src: 'https://img.oemoffhighway.com/files/base/acbm/ooh/image/static/engine.png',
   },
   downloadLink: '/12254042',
-  sheetSrc: 'https://spreadsheets.google.com/feeds/list/10EKomL-SVMZ4imnCaoO86t48T7ngVaopWXie04AveUo/4/public/values?alt=json',
+  sheetSrc: 'https://content-sheets.googleapis.com/v4/spreadsheets/10EKomL-SVMZ4imnCaoO86t48T7ngVaopWXie04AveUo/values/Engine-2021',
   measures: {
     metric: { label: 'Metric' },
     standard: { label: 'Standard' },

--- a/sites/oemoffhighway.com/config/spec-guides/motor.js
+++ b/sites/oemoffhighway.com/config/spec-guides/motor.js
@@ -10,7 +10,7 @@ module.exports = {
     src: 'https://img.oemoffhighway.com/files/base/acbm/ooh/image/static/motor.png',
   },
   downloadLink: '/20839229',
-  sheetSrc: 'https://spreadsheets.google.com/feeds/list/10EKomL-SVMZ4imnCaoO86t48T7ngVaopWXie04AveUo/6/public/values?alt=json',
+  sheetSrc: 'https://content-sheets.googleapis.com/v4/spreadsheets/10EKomL-SVMZ4imnCaoO86t48T7ngVaopWXie04AveUo/values/Motor-2016',
   measures: {
     metric: { label: 'Metric' },
     standard: { label: 'Standard' },

--- a/sites/oemoffhighway.com/config/spec-guides/pump.js
+++ b/sites/oemoffhighway.com/config/spec-guides/pump.js
@@ -10,7 +10,7 @@ module.exports = {
     src: 'https://img.oemoffhighway.com/files/base/acbm/ooh/image/static/pump.png',
   },
   downloadLink: '/20839221',
-  sheetSrc: 'https://spreadsheets.google.com/feeds/list/10EKomL-SVMZ4imnCaoO86t48T7ngVaopWXie04AveUo/5/public/values?alt=json',
+  sheetSrc: 'https://content-sheets.googleapis.com/v4/spreadsheets/10EKomL-SVMZ4imnCaoO86t48T7ngVaopWXie04AveUo/values/Pump-2016',
   measures: {
     metric: { label: 'Metric' },
     standard: { label: 'Standard' },


### PR DESCRIPTION
 - Add new spec-guide fetch route(__sec-guide?src=${sheetSrc}) that retrieves sheet data with api key set
 - Add table component logic to handle new data format.  Previously each row would have come back with `gsx$${key}.$t: value` array. Now it just returns an array of values.  I added logic to key each row off of row one column header. line 400-408 in packages/common/browser/spec-guide/table.vue 
 - Update FCP & OEM spec guide configs sheet src