### PR TITLE
Remove the Reskin ad from 'Page' content type.

### DIFF
--- a/packages/refresh-theme/templates/dynamic-page/index.marko
+++ b/packages/refresh-theme/templates/dynamic-page/index.marko
@@ -8,7 +8,6 @@ $ const { id, alias, pageNode } = data;
     </marko-web-gtm-dynamic-page-context>
   </@head>
   <@above-container>
-    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin" }) />
     <marko-web-resolve-page|{ data: page }| node=pageNode>
       <refresh-theme-parsely-dynamic-page page=page />
     </marko-web-resolve-page>


### PR DESCRIPTION
<img width="1791" alt="Screen Shot 2021-09-20 at 8 11 10 AM" src="https://user-images.githubusercontent.com/46794001/134008213-1ae7085d-71b0-493b-9482-cdf0678de404.png"
<img width="1792" alt="Screen Shot 2021-09-20 at 8 11 22 AM" src="https://user-images.githubusercontent.com/46794001/134008224-5995052a-65f5-4248-9a7f-9ad850f733fe.png">
>


I also doubled checked and confirmed no other content types are using this layout besides pages.