### PR TITLE
Add User-agent grapeshot, allow crawl on all pages

### DIFF
--- a/sites/dmnews.com/server/public/robots.txt
+++ b/sites/dmnews.com/server/public/robots.txt
@@ -1,6 +1,9 @@
 # www.robotstxt.org/
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
+User-agent: grapeshot
+Disallow:
+
 User-agent: *
 Disallow: /
 Disallow: /__

--- a/sites/foodlogistics.com/server/public/robots.txt
+++ b/sites/foodlogistics.com/server/public/robots.txt
@@ -1,6 +1,9 @@
 # www.robotstxt.org/
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
+User-agent: grapeshot
+Disallow:
+
 User-agent: *
 Disallow: /__
 Disallow: /print/content

--- a/sites/forconstructionpros.com/server/public/robots.txt
+++ b/sites/forconstructionpros.com/server/public/robots.txt
@@ -1,6 +1,9 @@
 # www.robotstxt.org/
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
+User-agent: grapeshot
+Disallow:
+
 User-agent: *
 Disallow: /__
 Disallow: /print/content

--- a/sites/greenindustrypros.com/server/public/robots.txt
+++ b/sites/greenindustrypros.com/server/public/robots.txt
@@ -1,6 +1,9 @@
 # www.robotstxt.org/
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
+User-agent: grapeshot
+Disallow:
+
 User-agent: *
 Disallow: /__
 Disallow: /print/content

--- a/sites/mixequipmentmag.com/server/public/robots.txt
+++ b/sites/mixequipmentmag.com/server/public/robots.txt
@@ -1,6 +1,9 @@
 # www.robotstxt.org/
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
+User-agent: grapeshot
+Disallow:
+
 User-agent: *
 Disallow: /__
 Disallow: /print/content

--- a/sites/oemoffhighway.com/server/public/robots.txt
+++ b/sites/oemoffhighway.com/server/public/robots.txt
@@ -1,6 +1,9 @@
 # www.robotstxt.org/
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
+User-agent: grapeshot
+Disallow:
+
 User-agent: *
 Disallow: /__
 Disallow: /print/content

--- a/sites/safesecureopenings.com/server/public/robots.txt
+++ b/sites/safesecureopenings.com/server/public/robots.txt
@@ -1,6 +1,9 @@
 # www.robotstxt.org/
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
+User-agent: grapeshot
+Disallow:
+
 User-agent: *
 Disallow: /__
 Disallow: /print/content

--- a/sites/sdcexec.com/server/public/robots.txt
+++ b/sites/sdcexec.com/server/public/robots.txt
@@ -1,6 +1,9 @@
 # www.robotstxt.org/
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
+User-agent: grapeshot
+Disallow:
+
 User-agent: *
 Disallow: /__
 Disallow: /print/content


### PR DESCRIPTION
Consulted http://www.robotstxt.org/orig.html 

"User-agent
The value of this field is the name of the robot the record is describing access policy for.
If more than one User-agent field is present the record describes an identical access policy for more than one robot. At least one field needs to be present per record.

The robot should be liberal in interpreting this field. A case insensitive substring match of the name without version information is recommended.

If the value is '*', the record describes the default access policy for any robot that has **_not_** matched any of the other records. It is not allowed to have multiple such records in the "/robots.txt" file."