### PR TITLE
Remove ‘Minexpo 2021’ from OEM nav bar

### DIFF
--- a/sites/oemoffhighway.com/config/navigation.js
+++ b/sites/oemoffhighway.com/config/navigation.js
@@ -7,7 +7,6 @@ module.exports = {
       { href: '/electronics', label: 'Electronics' },
       { href: '/operator-cab', label: 'Operator Cab' },
       { href: '/engineering-manufacturing', label: 'Engineering & Manufacturing' },
-      { href: '/minexpo-2021', label: 'MINExpo 2021' },
     ],
   },
   secondary: {


### PR DESCRIPTION
<img width="1314" alt="Screen Shot 2022-01-10 at 7 29 35 AM" src="https://user-images.githubusercontent.com/64623209/148774196-b91d553a-7878-4582-9bd0-4e962a40440f.png">
