### PR TITLE
Remove top social share from default content layout

### DIFF
--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -112,7 +112,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 <@section name=section.name hierarchy=section.hierarchy />
               </refresh-theme-content-section-logo>
 
-              <if(displaySocialShare)>
+              <!-- <if(displaySocialShare)>
                 <marko-web-social-sharing
                   path=content.siteContext.path
                   providers=["email", "facebook", "linkedin", "twitter"]
@@ -120,7 +120,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                   description=content.teaser
                   media=get(content, "primaryImage.src")
                 />
-              </if>
+              </if> -->
             </div>
           </div>
         </@section>


### PR DESCRIPTION
<img width="1064" alt="Screen Shot 2022-02-28 at 9 45 58 AM" src="https://user-images.githubusercontent.com/2855198/156013141-d7a8276b-8958-44be-8b47-a7b70238e251.png">
