### PR TITLE
Update contact us page content node layout

### DIFF
--- a/packages/refresh-theme/components/nodes/contact-us-list.marko
+++ b/packages/refresh-theme/components/nodes/contact-us-list.marko
@@ -3,13 +3,14 @@ import { getAsObject } from "@parameter1/base-cms-object-path";
 $ const content = getAsObject(input, "node");
 $ const primaryImage = getAsObject(content, "primaryImage");
 
-<marko-web-node image-position="left" flush-x=true>
+<marko-web-node image-position="center" flush-x=true>
   <@image
     src=primaryImage.src
     alt=primaryImage.alt
     fluid=false
-    ar=null
-    width=150
+    ar='3:2'
+    width=320
+    isLogo=primaryImage.isLogo
     link={ href: content.canonicalPath }
     use-placeholder=false
   />

--- a/packages/refresh-theme/scss/theme.scss
+++ b/packages/refresh-theme/scss/theme.scss
@@ -979,3 +979,21 @@ $theme-related-content-border-color: #dee2e6;
   margin-top: -150px;
   background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, #fff 100%);
 }
+
+.page-wrapper {
+  &--contact-us {
+    .node {
+      @include media-breakpoint-up(md) {
+        @include make-col(6);
+      }
+      &__title {
+        margin-top: map-get($spacers, block);
+        margin-bottom: 0;
+        padding-bottom: 0;
+      }
+      .page-contact-details__section {
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/packages/refresh-theme/templates/website-section/contact-us.marko
+++ b/packages/refresh-theme/templates/website-section/contact-us.marko
@@ -26,7 +26,7 @@ $ const {
   </@above-container>
   <@page>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
-      <marko-web-page-wrapper>
+      <marko-web-page-wrapper modifiers=["contact-us"]>
         <@section>
           <marko-web-gam-define-display-ad
             ...GAM.getAdUnit({ name: "lb1" })
@@ -45,9 +45,11 @@ $ const {
           <div class="row">
             <default-theme-page-contents|{ blockName }| class="col-lg-8 mb-3 mb-lg-0">
               <marko-web-query|{ nodes }| name="website-scheduled-content" params={ sectionId: id, limit: 100, queryFragment }>
-                <for|node| of=nodes>
-                  <refresh-theme-contact-us-list-node node=node />
-                </for>
+                <div class="row">
+                  <for|node| of=nodes>
+                    <refresh-theme-contact-us-list-node node=node />
+                  </for>
+                </div>
               </marko-web-query>
             </default-theme-page-contents>
             <aside class="col-lg-4 page-rail">


### PR DESCRIPTION
make this a two column layout with more of a card feel.  Image centered above with details below.
<img width="621" alt="Screen Shot 2022-04-19 at 2 22 41 PM" src="https://user-images.githubusercontent.com/3845869/164080632-4d7dffab-0d86-4a72-b2f8-ce2ca21a0ff9.png">
<img width="633" alt="Screen Shot 2022-04-19 at 2 22 48 PM" src="https://user-images.githubusercontent.com/3845869/164080646-f069c478-8662-405f-b9d9-13d2c74d5626.png">
<img width="623" alt="Screen Shot 2022-04-19 at 2 22 56 PM" src="https://user-images.githubusercontent.com/3845869/164080649-e8455bfd-7896-476d-850c-3133c3253f5c.png">

