### PR TITLE
Allow scheduling to recommended block by section FCP

### DIFF
--- a/packages/refresh-theme/components/blocks/marko.json
+++ b/packages/refresh-theme/components/blocks/marko.json
@@ -32,7 +32,8 @@
       "@aliases": "array"
     },
     "@skip": "number",
-    "@section-alias": "string"
+    "@section-alias": "string",
+    "@content-id": "number"
   },
   "<refresh-theme-related-content-block>": {
     "template": "./related-content.marko",

--- a/packages/refresh-theme/components/blocks/marko.json
+++ b/packages/refresh-theme/components/blocks/marko.json
@@ -31,7 +31,8 @@
       "@name": "string",
       "@aliases": "array"
     },
-    "@skip": "number"
+    "@skip": "number",
+    "@section-alias": "string"
   },
   "<refresh-theme-related-content-block>": {
     "template": "./related-content.marko",

--- a/packages/refresh-theme/components/blocks/recommended.marko
+++ b/packages/refresh-theme/components/blocks/recommended.marko
@@ -25,7 +25,7 @@ $ const params = {
   </refresh-theme-content-card-deck-flow>
   </if>
   <else>
-  $ const excludeContentIds = [...nodes.map((node) => node.id)];
+  $ const excludeContentIds = nodes.map((node) => node.id);
   $ if (input.contentId) excludeContentIds.push(input.contentId);
   $ const homeParams = {
   ...params,

--- a/packages/refresh-theme/components/blocks/recommended.marko
+++ b/packages/refresh-theme/components/blocks/recommended.marko
@@ -1,8 +1,12 @@
-import { getAsObject } from "@parameter1/base-cms-object-path";
+import { getAsObject, get } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/content-list";
+$ const { config } = out.global;
+
+$ const useSectionAlias = ["53ca8d671784f8066eb2c949"].includes(get(config, 'websiteContext.id')) && input.sectionAlias;
+$ const sectionAlias =  useSectionAlias ? input.sectionAlias : "home"
 
 $ const params = {
-  sectionAlias: "home",
+  sectionAlias,
   optionName: "Recommended",
   limit: 3,
   skip: input.skip,

--- a/packages/refresh-theme/components/blocks/recommended.marko
+++ b/packages/refresh-theme/components/blocks/recommended.marko
@@ -25,11 +25,13 @@ $ const params = {
   </refresh-theme-content-card-deck-flow>
   </if>
   <else>
+  $ const excludeContentIds = [...nodes.map((node) => node.id)];
+  $ if (input.contentId) excludeContentIds.push(input.contentId);
   $ const homeParams = {
   ...params,
   sectionAlias: "home",
   limit: 3 - nodes.length,
-  excludeContentIds: [input.contentId, ...nodes.map((node) => node.id)]
+  excludeContentIds
 }
   <marko-web-query|{ nodes: homeSectionNodes }| name="website-scheduled-content" params=homeParams>
     $ nodes.push(...homeSectionNodes)

--- a/packages/refresh-theme/components/blocks/recommended.marko
+++ b/packages/refresh-theme/components/blocks/recommended.marko
@@ -11,14 +11,31 @@ $ const params = {
   limit: 3,
   skip: input.skip,
   requiresImage: true,
+  ...(input.contentId && { excludeContentIds: [input.contentId] }),
   queryFragment,
 };
 
-<marko-web-query|{ nodes }| name="website-scheduled-content" params=params>
-  <marko-web-node-list>
+<marko-web-query|{ nodes }| name="website-scheduled-content" params=params collapsible=false>
+  <marko-web-node-list collapsible=false>
     <@header modifiers=["padding-y"]>Recommended</@header>
   </marko-web-node-list>
+  <if(nodes.length === 3)>
   <refresh-theme-content-card-deck-flow nodes=nodes>
     <@native-x ...getAsObject(input, "nativeX") />
   </refresh-theme-content-card-deck-flow>
+  </if>
+  <else>
+  $ const homeParams = {
+  ...params,
+  sectionAlias: "home",
+  limit: 3 - nodes.length,
+  excludeContentIds: [input.contentId, ...nodes.map((node) => node.id)]
+}
+  <marko-web-query|{ nodes: homeSectionNodes }| name="website-scheduled-content" params=homeParams>
+    $ nodes.push(...homeSectionNodes)
+    <refresh-theme-content-card-deck-flow nodes=nodes>
+      <@native-x ...getAsObject(input, "nativeX") />
+    </refresh-theme-content-card-deck-flow>
+  </marko-web-query>
+  </else>
 </marko-web-query>

--- a/packages/refresh-theme/components/blocks/recommended.marko
+++ b/packages/refresh-theme/components/blocks/recommended.marko
@@ -28,11 +28,11 @@ $ const params = {
   $ const excludeContentIds = nodes.map((node) => node.id);
   $ if (input.contentId) excludeContentIds.push(input.contentId);
   $ const homeParams = {
-  ...params,
-  sectionAlias: "home",
-  limit: 3 - nodes.length,
-  excludeContentIds
-}
+    ...params,
+    sectionAlias: "home",
+    limit: 3 - nodes.length,
+    excludeContentIds
+  };
   <marko-web-query|{ nodes: homeSectionNodes }| name="website-scheduled-content" params=homeParams>
     $ nodes.push(...homeSectionNodes)
     <refresh-theme-content-card-deck-flow nodes=nodes>

--- a/packages/refresh-theme/components/blocks/recommended.marko
+++ b/packages/refresh-theme/components/blocks/recommended.marko
@@ -15,7 +15,7 @@ $ const params = {
 };
 
 <marko-web-query|{ nodes }| name="website-scheduled-content" params=params>
-  <marko-web-node-list collapsible=false>
+  <marko-web-node-list>
     <@header modifiers=["padding-y"]>Recommended</@header>
   </marko-web-node-list>
   <refresh-theme-content-card-deck-flow nodes=nodes>

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -303,7 +303,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
 
         <if(displayRecommended)>
           <@section modifiers=["card-deck"]>
-            <refresh-theme-recommended-block>
+            <refresh-theme-recommended-block section-alias=get(content, "primarySection.alias")>
               <@native-x indexes=[2] name="default" aliases=aliases />
             </refresh-theme-recommended-block>
           </@section>

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -303,7 +303,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
 
         <if(displayRecommended)>
           <@section modifiers=["card-deck"]>
-            <refresh-theme-recommended-block section-alias=get(content, "primarySection.alias")>
+            <refresh-theme-recommended-block section-alias=get(content, "primarySection.alias") content-id=id>
               <@native-x indexes=[2] name="default" aliases=aliases />
             </refresh-theme-recommended-block>
           </@section>

--- a/packages/refresh-theme/templates/index.marko
+++ b/packages/refresh-theme/templates/index.marko
@@ -81,7 +81,7 @@ $ const adSlots = ({ aliases }) => ({
         </@section>
 
         <@section modifiers=["card-deck"]>
-          <refresh-theme-recommended-block>
+          <refresh-theme-recommended-block section-alias=alias>
             <@native-x indexes=[2] name="default" aliases=aliases />
           </refresh-theme-recommended-block>
         </@section>

--- a/packages/refresh-theme/templates/website-section/index.marko
+++ b/packages/refresh-theme/templates/website-section/index.marko
@@ -107,7 +107,7 @@ $ const adSlots = ({ aliases }) => ({
           </@section>
 
           <@section modifiers=["card-deck"]>
-            <refresh-theme-recommended-block>
+            <refresh-theme-recommended-block section-alias=alias>
               <@native-x indexes=[2] name="default" aliases=aliases />
             </refresh-theme-recommended-block>
           </@section>

--- a/sites/forconstructionpros.com/server/templates/index.marko
+++ b/sites/forconstructionpros.com/server/templates/index.marko
@@ -81,7 +81,7 @@ $ const adSlots = ({ aliases }) => ({
         </@section>
 
         <@section modifiers=["card-deck"]>
-          <refresh-theme-recommended-block>
+          <refresh-theme-recommended-block section-alias=alias>
             <@native-x indexes=[2] name="default" aliases=aliases />
           </refresh-theme-recommended-block>
         </@section>


### PR DESCRIPTION
FCP (Uses the primary section of the content on content pages):
<img width="1920" alt="Screen Shot 2022-05-09 at 11 07 47 AM" src="https://user-images.githubusercontent.com/46794001/167454036-81348ece-924e-43bf-83f5-b1ba6462591f.png">


GIP (Unchanged will always use recommended option schedules to home)
<img width="1919" alt="Screen Shot 2022-05-09 at 11 07 59 AM" src="https://user-images.githubusercontent.com/46794001/167454051-eddda3b6-6d85-487e-8f23-8fffc41962c7.png">