### PR TITLE
Remove leaders from FL & SDC, FCP (homepage only)

### DIFF
--- a/sites/foodlogistics.com/config/site.js
+++ b/sites/foodlogistics.com/config/site.js
@@ -85,4 +85,13 @@ module.exports = {
     logo: 'https://img.foodlogistics.com/files/base/acbm/fl/image/static/logo/site_logo_large.png?h=60&auto=format,compress',
     bgColor: '#1a93f9',
   },
+  leaders: {
+    enabled: false,
+    title: 'Food Logistics Leaders',
+    alias: 'leaders/2020',
+    calloutValue: 'Leading Providers',
+    header: {
+      imgSrc: 'https://img.foodlogistics.com/files/base/acbm/sdce/image/static/sdc-leaders.png?h=85&auto=format,compress',
+    },
+  },
 };

--- a/sites/foodlogistics.com/config/site.js
+++ b/sites/foodlogistics.com/config/site.js
@@ -85,13 +85,4 @@ module.exports = {
     logo: 'https://img.foodlogistics.com/files/base/acbm/fl/image/static/logo/site_logo_large.png?h=60&auto=format,compress',
     bgColor: '#1a93f9',
   },
-  leaders: {
-    enabled: true,
-    title: 'Food Logistics Leaders',
-    alias: 'leaders/2020',
-    calloutValue: 'Leading Providers',
-    header: {
-      imgSrc: 'https://img.foodlogistics.com/files/base/acbm/sdce/image/static/sdc-leaders.png?h=85&auto=format,compress',
-    },
-  },
 };

--- a/sites/foodlogistics.com/server/routes/website-section.js
+++ b/sites/foodlogistics.com/server/routes/website-section.js
@@ -9,16 +9,10 @@ const webinars = require('@ac-business-media/refresh-theme/templates/website-sec
 const whitepapers = require('@ac-business-media/refresh-theme/templates/website-section/whitepapers');
 const contactUs = require('@ac-business-media/refresh-theme/templates/website-section/contact-us');
 const queryFragment = require('@ac-business-media/refresh-theme/graphql/fragments/website-section-page');
-const leadersFragment = require('@ac-business-media/refresh-theme/graphql/fragments/leaders-section');
-const leaders = require('@ac-business-media/refresh-theme/templates/website-section/leaders');
 
 const directory = require('../templates/website-section/directory');
 
 module.exports = (app) => {
-  app.get('/:alias(leaders)', withWebsiteSection({
-    template: leaders,
-    queryFragment: leadersFragment,
-  }));
   app.get('/:alias(directory)', withWebsiteSection({
     template: directory,
     queryFragment,

--- a/sites/foodlogistics.com/server/styles/index.scss
+++ b/sites/foodlogistics.com/server/styles/index.scss
@@ -35,8 +35,4 @@ $theme-site-navbar-primary-font-size-sm: 12px !default;
 $theme-site-navbar-secondary-font-size: 14px !default;
 $theme-site-navbar-secondary-font-size-sm: 14px !default;
 
-$leaders-primary-color: #212121;
-$leaders-primary-color-light: lighten($leaders-primary-color, 10%);
-$leaders-accent-color: #212121;
-
 @import "../../node_modules/@ac-business-media/refresh-theme/scss/theme";

--- a/sites/forconstructionpros.com/server/templates/index.marko
+++ b/sites/forconstructionpros.com/server/templates/index.marko
@@ -119,6 +119,8 @@ $ const adSlots = ({ aliases }) => ({
             <aside class="col-lg-4 page-rail">
               <refresh-theme-follow-us-block />
 
+              <refresh-theme-newsletter-signup-block modifiers=["margin-top"] />
+
               <marko-web-gam-display-ad
                 id="gpt-ad-rail1"
                 modifiers=["sticky-top", "max-width-300", "margin-auto-x-md"]
@@ -139,19 +141,6 @@ $ const adSlots = ({ aliases }) => ({
       <marko-web-resolve-page|{ data: section, resolved }| node=pageNode>
         $ const aliases = hierarchyAliases(section);
         <marko-web-page-wrapper>
-          <if(site.get("leaders.enabled"))>
-            <@section>
-              <div class="row">
-                <div class="col-lg-8 mb-block">
-                  <leaders-home-page />
-                </div>
-                <div class="col-lg-4 mb-block">
-                  <refresh-theme-newsletter-signup-block modifiers=["margin-top"] />
-                </div>
-              </div>
-            </@section>
-          </if>
-
           <@section>
             <div class="row">
               <div class="col">

--- a/sites/sdcexec.com/config/site.js
+++ b/sites/sdcexec.com/config/site.js
@@ -85,13 +85,4 @@ module.exports = {
     logo: 'https://img.sdcexec.com/files/base/acbm/sdce/image/static/logo/site_logo_og.png?h=60&auto=format,compress',
     bgColor: '#ec131c',
   },
-  leaders: {
-    enabled: true,
-    title: 'Supply Chain Leaders',
-    alias: 'leaders/2020',
-    calloutValue: 'Leading Companies',
-    header: {
-      imgSrc: 'https://img.sdcexec.com/files/base/acbm/sdce/image/static/sdc-leaders.png?h=85&auto=format,compress',
-    },
-  },
 };

--- a/sites/sdcexec.com/config/site.js
+++ b/sites/sdcexec.com/config/site.js
@@ -85,4 +85,13 @@ module.exports = {
     logo: 'https://img.sdcexec.com/files/base/acbm/sdce/image/static/logo/site_logo_og.png?h=60&auto=format,compress',
     bgColor: '#ec131c',
   },
+  leaders: {
+    enabled: false,
+    title: 'Supply Chain Leaders',
+    alias: 'leaders/2020',
+    calloutValue: 'Leading Companies',
+    header: {
+      imgSrc: 'https://img.sdcexec.com/files/base/acbm/sdce/image/static/sdc-leaders.png?h=85&auto=format,compress',
+    },
+  },
 };

--- a/sites/sdcexec.com/server/routes/website-section.js
+++ b/sites/sdcexec.com/server/routes/website-section.js
@@ -9,16 +9,10 @@ const media = require('@ac-business-media/refresh-theme/templates/website-sectio
 const webinars = require('@ac-business-media/refresh-theme/templates/website-section/webinars');
 const whitepapers = require('@ac-business-media/refresh-theme/templates/website-section/whitepapers');
 const queryFragment = require('@ac-business-media/refresh-theme/graphql/fragments/website-section-page');
-const leadersFragment = require('@ac-business-media/refresh-theme/graphql/fragments/leaders-section');
-const leaders = require('@ac-business-media/refresh-theme/templates/website-section/leaders');
 
 const directory = require('../templates/website-section/directory');
 
 module.exports = (app) => {
-  app.get('/:alias(leaders)', withWebsiteSection({
-    template: leaders,
-    queryFragment: leadersFragment,
-  }));
   app.get('/:alias(directory)', withWebsiteSection({
     template: directory,
     queryFragment,

--- a/sites/sdcexec.com/server/styles/index.scss
+++ b/sites/sdcexec.com/server/styles/index.scss
@@ -35,8 +35,4 @@ $theme-site-navbar-primary-font-size-sm: 12px !default;
 $theme-site-navbar-secondary-font-size: 14px !default;
 $theme-site-navbar-secondary-font-size-sm: 14px !default;
 
-$leaders-primary-color: #212121;
-$leaders-primary-color-light: lighten($leaders-primary-color, 10%);
-$leaders-accent-color: #212121;
-
 @import "../../node_modules/@ac-business-media/refresh-theme/scss/theme";


### PR DESCRIPTION
SDC homepage:
<img width="746" alt="Screen Shot 2022-05-10 at 10 15 55 AM" src="https://user-images.githubusercontent.com/64623209/167666271-0831f260-b07e-4995-834c-7a29b6098d08.png">
FL homepage:
<img width="753" alt="Screen Shot 2022-05-10 at 10 12 47 AM" src="https://user-images.githubusercontent.com/64623209/167666312-38a933c8-5dab-419b-95c0-7d0daf5895d8.png">
SDC content page:
<img width="386" alt="Screen Shot 2022-05-10 at 10 21 27 AM" src="https://user-images.githubusercontent.com/64623209/167666445-220beca6-1c81-4a33-ade8-ac22c3acbc5e.png">
FL content page:
<img width="583" alt="Screen Shot 2022-05-10 at 10 24 20 AM" src="https://user-images.githubusercontent.com/64623209/167666450-8470ab1f-04d8-437a-89ce-03db421e0f04.png">
FCP homepage:
<img width="652" alt="Screen Shot 2022-05-10 at 10 27 36 AM" src="https://user-images.githubusercontent.com/64623209/167666591-4426e9d6-6ad3-4dbf-8fad-a505f1983d6d.png">
FCP content page (still has 'Leaders'):
<img width="825" alt="Screen Shot 2022-05-10 at 10 28 41 AM" src="https://user-images.githubusercontent.com/64623209/167666665-85340f6f-218a-4c25-8403-1c14d197ae87.png">
