### PR TITLE
Update refresh-theme-template-index file…

### DIFF
--- a/packages/refresh-theme/templates/index.marko
+++ b/packages/refresh-theme/templates/index.marko
@@ -109,54 +109,33 @@ $ const adSlots = ({ aliases }) => ({
               </div>
             </div>
           </@section>
-
-          <@section>
-            <div class="row">
-              <div class="col-lg-8">
-                <marko-web-query|{ nodes }|
-                  name="all-published-content"
-                  params={ excludeContentTypes, limit: 6, requiresImage: true, queryFragment }
-                >
-                  <refresh-theme-latest-content-list-flow nodes=nodes with-header=true />
-                </marko-web-query>
-              </div>
-              <aside class="col-lg-4 page-rail">
-                <refresh-theme-follow-us-block />
-
-                <marko-web-gam-display-ad
-                  id="gpt-ad-rail1"
-                  modifiers=["sticky-top", "max-width-300", "margin-auto-x-md"]
-                  slots=adSlots({ aliases })
-                />
-              </aside>
-            </div>
-          </@section>
         </if>
-        <else>
-          <@section>
-            <div class="row">
-              <div class="col-lg-8">
-                <marko-web-query|{ nodes }|
-                  name="all-published-content"
-                  params={ excludeContentTypes, limit: 6, requiresImage: true, queryFragment }
-                >
-                  <refresh-theme-latest-content-list-flow nodes=nodes with-header=true />
-                </marko-web-query>
-              </div>
-              <aside class="col-lg-4 page-rail">
-                <refresh-theme-follow-us-block />
 
-                <refresh-theme-newsletter-signup-block modifiers=["margin-top"] />
-
-                <marko-web-gam-display-ad
-                  id="gpt-ad-rail1"
-                  modifiers=["sticky-top", "max-width-300", "margin-auto-x-md"]
-                  slots=adSlots({ aliases })
-                />
-              </aside>
+        <@section>
+          <div class="row">
+            <div class="col-lg-8">
+              <marko-web-query|{ nodes }|
+                name="all-published-content"
+                params={ excludeContentTypes, limit: 6, requiresImage: true, queryFragment }
+              >
+                <refresh-theme-latest-content-list-flow nodes=nodes with-header=true />
+              </marko-web-query>
             </div>
-          </@section>
-        </else>
+            <aside class="col-lg-4 page-rail">
+              <refresh-theme-follow-us-block />
+
+              <if(!site.get("leaders.enabled"))>
+                <refresh-theme-newsletter-signup-block modifiers=["margin-top"] />
+              </if>
+
+              <marko-web-gam-display-ad
+                id="gpt-ad-rail1"
+                modifiers=["sticky-top", "max-width-300", "margin-auto-x-md"]
+                slots=adSlots({ aliases })
+              />
+            </aside>
+          </div>
+        </@section>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>

--- a/packages/refresh-theme/templates/index.marko
+++ b/packages/refresh-theme/templates/index.marko
@@ -109,29 +109,54 @@ $ const adSlots = ({ aliases }) => ({
               </div>
             </div>
           </@section>
-        </if>
 
-        <@section>
-          <div class="row">
-            <div class="col-lg-8">
-              <marko-web-query|{ nodes }|
-                name="all-published-content"
-                params={ excludeContentTypes, limit: 6, requiresImage: true, queryFragment }
-              >
-                <refresh-theme-latest-content-list-flow nodes=nodes with-header=true />
-              </marko-web-query>
+          <@section>
+            <div class="row">
+              <div class="col-lg-8">
+                <marko-web-query|{ nodes }|
+                  name="all-published-content"
+                  params={ excludeContentTypes, limit: 6, requiresImage: true, queryFragment }
+                >
+                  <refresh-theme-latest-content-list-flow nodes=nodes with-header=true />
+                </marko-web-query>
+              </div>
+              <aside class="col-lg-4 page-rail">
+                <refresh-theme-follow-us-block />
+
+                <marko-web-gam-display-ad
+                  id="gpt-ad-rail1"
+                  modifiers=["sticky-top", "max-width-300", "margin-auto-x-md"]
+                  slots=adSlots({ aliases })
+                />
+              </aside>
             </div>
-            <aside class="col-lg-4 page-rail">
-              <refresh-theme-follow-us-block />
+          </@section>
+        </if>
+        <else>
+          <@section>
+            <div class="row">
+              <div class="col-lg-8">
+                <marko-web-query|{ nodes }|
+                  name="all-published-content"
+                  params={ excludeContentTypes, limit: 6, requiresImage: true, queryFragment }
+                >
+                  <refresh-theme-latest-content-list-flow nodes=nodes with-header=true />
+                </marko-web-query>
+              </div>
+              <aside class="col-lg-4 page-rail">
+                <refresh-theme-follow-us-block />
 
-              <marko-web-gam-display-ad
-                id="gpt-ad-rail1"
-                modifiers=["sticky-top", "max-width-300", "margin-auto-x-md"]
-                slots=adSlots({ aliases })
-              />
-            </aside>
-          </div>
-        </@section>
+                <refresh-theme-newsletter-signup-block modifiers=["margin-top"] />
+
+                <marko-web-gam-display-ad
+                  id="gpt-ad-rail1"
+                  modifiers=["sticky-top", "max-width-300", "margin-auto-x-md"]
+                  slots=adSlots({ aliases })
+                />
+              </aside>
+            </div>
+          </@section>
+        </else>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>


### PR DESCRIPTION
If check to allow FCP to still show ‘Leaders’ on content page, but now add newsletter signup block to all sites