### PR TITLE
Update spec guide pages with new GTM context for static_page olytics tracking

### DIFF
--- a/packages/refresh-theme/templates/spec-guide/guide.marko
+++ b/packages/refresh-theme/templates/spec-guide/guide.marko
@@ -1,6 +1,6 @@
 import { get, getAsArray } from "@parameter1/base-cms-object-path";
 
-$ const { GAM, specGuides } = out.global;
+$ const { GAM, specGuides, userState } = out.global;
 $ const type = "spec-guide";
 $ const { title, description, alias } = data;
 
@@ -11,10 +11,18 @@ $ const adSlots = () => ({
   "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1" }),
 });
 
-<marko-web-default-page-layout type=type title=title description=description>
+<marko-web-default-page-layout type=type title=config.title description=config.description>
   <@head>
     <marko-web-gtm-default-context|{ context }| type=type>
-      <marko-web-gtm-push data=context />
+      $ const ctx = {
+        ...context,
+        page_type: "static-page",
+        static_page: {
+          title: config.title
+        },
+        userState,
+      };
+      <marko-web-gtm-push data=ctx />
     </marko-web-gtm-default-context>
     <marko-web-gam-slots slots=adSlots() />
   </@head>


### PR DESCRIPTION
update the context that is being passed to GTM in order to track the spec guides as staic pages within olytics.  This will push the new static_page object
// at minimum
{
  title: “blah”
}

to the gtm data layer.  This is used in the olytics script to fire a static page view with { behaviorId, name, pageType }.  We can look at adding more as needed.

<img width="374" alt="Screen Shot 2022-06-07 at 11 38 03 AM" src="https://user-images.githubusercontent.com/3845869/172436213-348b27b3-ff23-404a-a839-63b3c007a68e.png">

