### PR TITLE
Remove server requirement for region/postal codes

### DIFF
--- a/packages/refresh-theme/config/identity-x.js
+++ b/packages/refresh-theme/config/identity-x.js
@@ -10,9 +10,7 @@ module.exports = ({
     'givenName',
     'familyName',
     'organization',
-    'regionCode',
     'countryCode',
-    'postalCode',
   ],
   requiredClientFields = [
     'regionCode',


### PR DESCRIPTION
Still required client-side when US/CA is selected,
<img width="675" alt="image" src="https://user-images.githubusercontent.com/1778222/173410641-37885044-366f-4e3c-a03f-9f22b15232f4.png">

but allows the gate to hide when a different country is selected.
<img width="663" alt="image" src="https://user-images.githubusercontent.com/1778222/173410683-5953a691-35cc-48ae-bc09-3668886c0262.png">
