### PR TITLE
Correction of query logic to use website-scheduled-content in applicable locations

### DIFF
--- a/packages/refresh-theme/components/blocks/content-infinite-scroll.marko
+++ b/packages/refresh-theme/components/blocks/content-infinite-scroll.marko
@@ -40,12 +40,11 @@ $ const createAttrs = () => {
   if (type === "webinar") {
     return {
       header: "More Webinars",
-      queryName: "all-published-content",
+      queryName: "website-scheduled-content",
       queryParams: {
-        contentTypes: ["Webinar"],
+        includeContentTypes: ["Webinar"],
         excludeContentIds: [id],
-        sortField: "startDate",
-        sortOrder: "desc",
+        sort: { field: "startDate", order: "desc", },
         limit,
         skip,
         queryFragment },
@@ -54,12 +53,11 @@ $ const createAttrs = () => {
   if (type === "event") {
     return {
       header: "More Events",
-      queryName: "all-published-content",
+      queryName: "website-scheduled-content",
       queryParams: {
-        contentTypes: ["Event"],
+        includeContentTypes: ["Event"],
         endingAfter: now,
-        sortField: "startDate",
-        sortOrder: "asc",
+        sort: { field: "startDate", order: "asc", },
         limit,
         skip,
         queryFragment },

--- a/packages/refresh-theme/components/blocks/featured-videos.marko
+++ b/packages/refresh-theme/components/blocks/featured-videos.marko
@@ -2,13 +2,13 @@ import queryFragment from "../../graphql/fragments/content-list";
 
 $ const params = {
   ...(input.sectionId && { sectionId: input.sectionId }),
-  contentTypes: ["Video"],
+  includeContentTypes: ["Video"],
   limit: 6,
   requiresImage: true,
   queryFragment,
 };
 
-<marko-web-query|{ nodes }| name="all-published-content" params=params>
+<marko-web-query|{ nodes }| name="website-scheduled-content" params=params>
   <marko-web-node-list collapsible=false>
     <@header modifiers=["padding-y"]>Featured Videos</@header>
   </marko-web-node-list>

--- a/packages/refresh-theme/components/blocks/most-read.marko
+++ b/packages/refresh-theme/components/blocks/most-read.marko
@@ -1,7 +1,7 @@
 import queryFragment from "../../graphql/fragments/most-read-block";
 
 <marko-web-query|{ nodes }|
-  name="all-published-content"
+  name="website-scheduled-content"
   params={ excludeContentTypes: ["Contact", "Company", "Promotion"], limit: 6, queryFragment }
 >
   <refresh-theme-content-list-flow

--- a/packages/refresh-theme/templates/index.marko
+++ b/packages/refresh-theme/templates/index.marko
@@ -115,7 +115,7 @@ $ const adSlots = ({ aliases }) => ({
           <div class="row">
             <div class="col-lg-8">
               <marko-web-query|{ nodes }|
-                name="all-published-content"
+                name="website-scheduled-content"
                 params={ excludeContentTypes, limit: 6, requiresImage: true, queryFragment }
               >
                 <refresh-theme-latest-content-list-flow nodes=nodes with-header=true />
@@ -172,7 +172,7 @@ $ const adSlots = ({ aliases }) => ({
             <div class="row">
               <div class="col-lg-8 infinite-scroll-target">
                 <marko-web-query|{ nodes }|
-                  name="all-published-content"
+                  name="website-scheduled-content"
                   params={ excludeContentTypes, limit: 12, skip: 6, requiresImage: true, queryFragment: latestQueryFragment }
                 >
                   <refresh-theme-latest-content-list-flow nodes=nodes with-header=false>
@@ -182,7 +182,7 @@ $ const adSlots = ({ aliases }) => ({
 
                 <refresh-theme-latest-content-load-more-block max-pages=1>
                   <@query
-                    name="all-published-content"
+                    name="website-scheduled-content"
                     params={ excludeContentTypes, limit: 12, skip: 18, requiresImage: true }
                   />
                   <@page for="website-section" id=id />


### PR DESCRIPTION
Likewise to https://github.com/parameter1/ac-business-media-websites/pull/416 needs to be merged following https://github.com/parameter1/base-scripts/pull/106 being run on production.

![Homepage-fixed](https://user-images.githubusercontent.com/46794001/190182527-259eabea-8e92-46df-9b18-4123543e9e50.png)
![More-webinars](https://user-images.githubusercontent.com/46794001/190182539-cf7c948e-7024-444d-806e-5778233da7d5.png)
