### PR TITLE
Replace Leaders block on content pages with Native-X block

### DIFF
--- a/packages/refresh-theme/components/blocks/marko.json
+++ b/packages/refresh-theme/components/blocks/marko.json
@@ -112,6 +112,8 @@
     "@placement-name": "string",
     "@aliases": "array",
     "@modifiers": "array",
-    "@list": "object"
+    "@list": "object",
+    "@header-img-src": "string",
+    "@header-img-alt": "string"
   }
 }

--- a/packages/refresh-theme/components/blocks/marko.json
+++ b/packages/refresh-theme/components/blocks/marko.json
@@ -105,5 +105,13 @@
       "type": "object",
       "required": true
     }
+  },
+  "<refresh-theme-native-x-list-block>": {
+    "template": "./native-x-list-block.marko",
+    "@limit": "number",
+    "@placement-name": "string",
+    "@aliases": "array",
+    "@modifiers": "array",
+    "@list": "object"
   }
 }

--- a/packages/refresh-theme/components/blocks/native-x-list-block.marko
+++ b/packages/refresh-theme/components/blocks/native-x-list-block.marko
@@ -16,7 +16,6 @@ $ const displayHeader = defaultValue(input.displayHeader, true);
 
 <marko-web-native-x-fetch-elements|{ ads }| uri=uri id=placement.id opts={ n: limit }>
   $ const nodes = ads.filter(ad => ad.hasCampaign);
-  $ console.log(ads);
 
   <if(nodes.length)>
     <marko-web-node-list
@@ -31,7 +30,7 @@ $ const displayHeader = defaultValue(input.displayHeader, true);
         <@header>
           <div class="leaders__header">
             <div class="leaders__header-image">
-              <img src="https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/fcp-leaders.jpeg?h=85&auto=format,compress" alt="IronPros Sponsored Block Header">
+              <img src=input.headerImgSrc alt=input.headerImgAlt >
             </div>
           </div>
         </@header>

--- a/packages/refresh-theme/components/blocks/native-x-list-block.marko
+++ b/packages/refresh-theme/components/blocks/native-x-list-block.marko
@@ -1,0 +1,51 @@
+import { getAsObject, get } from "@parameter1/base-cms-object-path";
+import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
+import convertAdToContent from "@parameter1/base-cms-marko-web-native-x/utils/convert-ad-to-content";
+
+$ const { nativeX: nxConfig } = out.global;
+$ const limit = defaultValue(input.limit, 1);
+$ const placementName = defaultValue(input.placementName, "default");
+$ const aliases = defaultValue(input.aliases, []);
+
+$ const modifiers = input.modifiers || [];
+$ modifiers.push("native-x-list");
+$ const uri = nxConfig.getUri();
+$ const placement = nxConfig.getPlacement({ name: placementName, aliases });
+
+$ const displayHeader = defaultValue(input.displayHeader, true);
+
+<marko-web-native-x-fetch-elements|{ ads }| uri=uri id=placement.id opts={ n: limit }>
+  $ const nodes = ads.filter(ad => ad.hasCampaign);
+  $ console.log(ads);
+
+  <if(nodes.length)>
+    <marko-web-node-list
+      inner-justified=false
+      flush-x=false
+      flush-y=false
+      modifiers=modifiers
+      ...input.list
+    >
+
+      <if(displayHeader)>
+        <@header>
+          <div class="leaders__header">
+            <div class="leaders__header-image">
+              <img src="https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/fcp-leaders.jpeg?h=85&auto=format,compress" alt="IronPros Sponsored Block Header">
+            </div>
+          </div>
+        </@header>
+      </if>
+      <@nodes nodes=nodes>
+        <@slot|{ node: ad, index }|>
+          $ const node = convertAdToContent(ad);
+          <refresh-theme-content-card-node
+            node=node
+            attrs=getAsObject(node, "attributes.container")
+            link-attrs=getAsObject(node, "attributes.link")
+          />
+        </@slot>
+      </@nodes>
+    </marko-web-node-list>
+  </if>
+</marko-web-native-x-fetch-elements>

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -325,7 +325,13 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 />
               </refresh-theme-latest-in-section-block>
 
-              <refresh-theme-native-x-list-block aliases=site.getAsArray("nativeXBlockAliases") />
+              <if(site.getAsArray("nativeXBlock.aliases").length)>
+                <refresh-theme-native-x-list-block
+                  aliases=site.getAsArray("nativeXBlock.aliases")
+                  header-img-src=site.get("nativeXBlock.headerImgSrc")
+                  header-img-alt=site.get("nativeXBlock.headerImgAlt")
+                />
+             </if>
 
               <if(!isShortForm)>
                 <marko-web-gam-display-ad

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -325,7 +325,7 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 />
               </refresh-theme-latest-in-section-block>
 
-              <leaders-contextual content-id=id />
+              <refresh-theme-native-x-list-block aliases=site.getAsArray("nativeXBlockAliases") />
 
               <if(!isShortForm)>
                 <marko-web-gam-display-ad

--- a/sites/forconstructionpros.com/config/native-x.js
+++ b/sites/forconstructionpros.com/config/native-x.js
@@ -11,6 +11,7 @@ module.exports = {
     rental: '5b55e29d2360050001b7734c',
     'construction-technology': '5b55e3162360050001b77351',
     trucks: '5b55e1a52360050001b77343',
+    ironpros: '63863e54fc370c00019b2027',
   },
   content: {
     latestIn: {

--- a/sites/forconstructionpros.com/config/site.js
+++ b/sites/forconstructionpros.com/config/site.js
@@ -149,5 +149,9 @@ module.exports = {
   ],
   publishedContentMultisite: false,
   useSectionLogos: true,
-  nativeXBlockAliases: ['ironpros'],
+  nativeXBlock: {
+    aliases: ['ironpros'],
+    headerImgSrc: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/IP_Newswire_image.jpg?h=90&auto=format,compress',
+    headerImgAlt: 'IronPros Newswire Block Header',
+  },
 };

--- a/sites/forconstructionpros.com/config/site.js
+++ b/sites/forconstructionpros.com/config/site.js
@@ -149,4 +149,5 @@ module.exports = {
   ],
   publishedContentMultisite: false,
   useSectionLogos: true,
+  nativeXBlockAliases: ['ironpros'],
 };


### PR DESCRIPTION
This requires the appropriate configuration to enable on a given sites content pages, currently setup to operate on FCP.

FCP
![Screenshot from 2022-11-29 11-34-20](https://user-images.githubusercontent.com/46794001/204601987-133f5f7d-0898-4af2-aaa4-bd22b7f379fa.png)

FL (Example of site without the block appearing):
![Screenshot from 2022-11-29 11-38-22](https://user-images.githubusercontent.com/46794001/204602091-9b8b7c71-4c67-4dc5-88bc-ce215849761d.png)
