### PR TITLE
Set sticky bottom leaderboard default in core

### DIFF
--- a/packages/refresh-theme/gam/build-config.js
+++ b/packages/refresh-theme/gam/build-config.js
@@ -14,9 +14,10 @@ module.exports = ({
   },
 
   stickyBottomTemplate = {
-    size: [[320, 50], [300, 50]],
+    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50]],
     sizeMapping: [
-      { viewport: [576, 0], size: [] },
+      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
+      { viewport: [750, 0], size: [728, 90] },
       { viewport: [320, 0], size: [[300, 50], [320, 50]] },
     ],
   },

--- a/sites/foodlogistics.com/config/gam.js
+++ b/sites/foodlogistics.com/config/gam.js
@@ -132,12 +132,4 @@ module.exports = {
       },
     },
   ],
-  stickyBottomTemplate: {
-    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50]],
-    sizeMapping: [
-      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
-      { viewport: [750, 0], size: [728, 90] },
-      { viewport: [320, 0], size: [[300, 50], [320, 50]] },
-    ],
-  },
 };

--- a/sites/forconstructionpros.com/config/gam.js
+++ b/sites/forconstructionpros.com/config/gam.js
@@ -236,4 +236,12 @@ module.exports = {
       },
     },
   ],
+  // override to disable bottom sticky leaderboard
+  // stickyBottomTemplate: {
+  //   size: [[320, 50], [300, 50]],
+  //   sizeMapping: [
+  //     { viewport: [576, 0], size: [] },
+  //     { viewport: [320, 0], size: [[300, 50], [320, 50]] },
+  //   ],
+  // },
 };

--- a/sites/greenindustrypros.com/config/gam.js
+++ b/sites/greenindustrypros.com/config/gam.js
@@ -106,12 +106,4 @@ module.exports = {
       },
     },
   ],
-  stickyBottomTemplate: {
-    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50]],
-    sizeMapping: [
-      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
-      { viewport: [750, 0], size: [728, 90] },
-      { viewport: [320, 0], size: [[300, 50], [320, 50]] },
-    ],
-  },
 };

--- a/sites/oemoffhighway.com/config/gam.js
+++ b/sites/oemoffhighway.com/config/gam.js
@@ -145,12 +145,4 @@ module.exports = {
       },
     },
   ],
-  stickyBottomTemplate: {
-    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50]],
-    sizeMapping: [
-      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
-      { viewport: [750, 0], size: [728, 90] },
-      { viewport: [320, 0], size: [[300, 50], [320, 50]] },
-    ],
-  },
 };

--- a/sites/sdcexec.com/config/gam.js
+++ b/sites/sdcexec.com/config/gam.js
@@ -119,12 +119,4 @@ module.exports = {
       },
     },
   ],
-  stickyBottomTemplate: {
-    size: [[970, 90], [970, 66], [728, 90], [320, 50], [300, 50]],
-    sizeMapping: [
-      { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
-      { viewport: [750, 0], size: [728, 90] },
-      { viewport: [320, 0], size: [[300, 50], [320, 50]] },
-    ],
-  },
 };


### PR DESCRIPTION
Set the default in core for the sticky bottom leaderboard to be the default bottom sticky leaderboard and move the comment out ref for the non sticky leaderboard to FCP’s config.  Also remove un used overrides in other site configs.


![Screenshot 2024-01-12 at 10 15 22 AM](https://github.com/parameter1/ac-business-media-websites/assets/3845869/089e55e4-4644-48d0-821a-fdd471d5bfc7)
