### PR TITLE
Adjust homepage to include seciton graphics and callouts

### DIFF
--- a/packages/global/graphql/fragments/section-info.js
+++ b/packages/global/graphql/fragments/section-info.js
@@ -1,0 +1,17 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment GlobalSectionInfoWithLogoFragment on WebsiteSection {
+  id
+  name
+  description
+  fullName
+  canonicalPath
+  logo {
+    id
+    src(input: { options: { auto: "format,compress" } })
+  }
+}
+
+`;

--- a/sites/ironpros.com/server/components/blocks/home-section-list.marko
+++ b/sites/ironpros.com/server/components/blocks/home-section-list.marko
@@ -1,0 +1,105 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import cardFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-list-card-block";
+import listFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-list-block";
+import sectionFragment from "@ac-business-media/package-global/graphql/fragments/section-info";
+import { buildImgixUrl } from "@parameter1/base-cms-image";
+
+$ const { i18n } = out.global;
+
+$ const { alias, section: inputSection } = input;
+
+$ const withSection = defaultValue(input.withSection, true);
+$ const withViewMore = defaultValue(input.withViewMore, true);
+$ const sectionAlias = inputSection && inputSection.alias ? inputSection.alias : alias;
+
+$ const queryParams = {
+  limit: 4,
+  ...getAsObject(input, "queryParams"),
+  queryFragment: listFragment,
+  sectionFragment,
+  sectionAlias,
+};
+$ const heroParams = {
+  ...queryParams,
+  limit: 1,
+  requiresImage: true,
+  queryFragment: cardFragment,
+};
+
+$ const blockName = "section-list";
+
+<marko-web-query|{ nodes: heroNodes, section }| name="website-scheduled-content" params=heroParams>
+  $ console.log(section)
+  $ const listParams = {
+    ...queryParams,
+    limit: queryParams.limit - 1,
+    excludeContentIds: heroNodes.map((node) => node.id),
+    sectionFragment: undefined,
+  };
+  <marko-web-query|{ nodes: listNodes }| name="website-scheduled-content" params=listParams>
+    $ const nodes = [...heroNodes, ...listNodes];
+    <marko-web-node-list
+      inner-justified=true
+      flush-x=true
+      flush-y=true
+      modifiers=[blockName]
+      ...input.nodeList
+    >
+      <@header>
+        <marko-web-website-section-name block-name=blockName obj=section link=true />
+        <marko-web-link class=`${blockName}__logo-link` href=`/${sectionAlias}` title=section.name >
+          $ const src = buildImgixUrl(section.logo.src, { w: 600 });
+          $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
+          <marko-web-img
+            src=src
+            srcset=srcset
+            alt=section.name
+            class=`${blockName}__logo`
+            lazyload=true
+          />
+        </marko-web-link>
+        $ const obj = { ...section, ...inputSection };
+
+        <marko-web-website-section-description block-name=blockName obj=section />
+
+      </@header>
+      <@nodes nodes=nodes>
+        <@slot|{ node, index }|>
+          <!-- <if(index === 0)>
+            <theme-content-node
+              image-position="top"
+              card=true
+              flush=true
+              modifiers=[`${blockName}-card`]
+              with-teaser=false
+              with-dates=false
+              with-section=withSection
+              node=node
+            >
+              <@image fluid=true width=330 ar="3:2" />
+            </theme-content-node>
+          </if>
+          <else> -->
+            <theme-content-node
+              display-image=false
+              flush=true
+              modifiers=[`${blockName}-item`]
+              with-teaser=false
+              with-dates=false
+              with-section=withSection
+              node=node
+            />
+          <!-- </else> -->
+        </@slot>
+      </@nodes>
+      <if(withViewMore)>
+        <@footer modifiers=["view-more"]>
+          <marko-web-website-section-name obj=section link=true>
+            ${i18n("View More")} &raquo;
+          </marko-web-website-section-name>
+        </@footer>
+      </if>
+    </marko-web-node-list>
+  </marko-web-query>
+</marko-web-query>

--- a/sites/ironpros.com/server/components/blocks/marko.json
+++ b/sites/ironpros.com/server/components/blocks/marko.json
@@ -5,5 +5,8 @@
   "<site-image-slider>": {
     "template": "./image-slider.marko",
     "@images" : "array"
+  },
+  "<site-home-section-list-block>": {
+    "template": "./home-section-list.marko"
   }
 }

--- a/sites/ironpros.com/server/components/layouts/website-section/home.marko
+++ b/sites/ironpros.com/server/components/layouts/website-section/home.marko
@@ -58,43 +58,42 @@ $ const morePrefix = defaultValue(input.morePrefix, "More from");
               </div>
             </div>
           </@section>
+          <@section|{ blockName, section, aliases }| modifiers=["break-container"]>
+            <global-partners-block title="Titanium Partners"/>
+          </@section>
           <@section>
             <div class="section-list-deck section-list-deck--graphical-sections">
               <div class="section-list-deck__row">
-                $ const sections = ['equipment', 'technology', 'workwear'];
-                <for|alias| of=sections>
+                $ const sections = [
+                  {
+                    name: 'Equipment',
+                    alias: 'equipment',
+                    icon: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/iron/home-section-icons/equipment.png',
+                    // icon: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/2024/04/equipment_icon.661ff3d54142e.png',
+                    descriptioin: 'Insight and research over 2,000 new in-market machines for the heavy equipment Industry',
+                  },
+                  {
+                    name: 'Technology',
+                    alias: 'technology',
+                    icon: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/iron/home-section-icons/technology.png',
+                    // icon: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/2024/04/technology_icon.661ff75887aa8.png',
+                    descriptioin: 'Insight and research over 2,000 new in-market machines for the heavy equipment Industry',
+                  },
+                  {
+                    name: 'Workwear',
+                    alias: 'workwear',
+                    icon: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/iron/home-section-icons/workwear.png',
+                    // icon: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/2024/04/equipment_icon.661ff3d54142e.png',
+                    descriptioin: 'Insight and research over 2,000 new in-market machines for the heavy equipment Industry',
+                  },
+                ];
+                <for|{ name, alias: sectionAlias, icon, description }| of=sections>
                   <div class="section-list-deck__col">
-                    <div class="node-list node-list--section-list node-list--flush-x node-list--flush-y node-list--inner-justified">
-                      <div class="node-list__body">
-                        <marko-web-link href=`/${alias}` title=`${alias}`>
-                          $ const src = buildImgixUrl(`https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/iron/home-section-icons/${alias}.png`, { w: 600 });
-                          $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
-                          <marko-web-img
-                            src=src
-                            srcset=srcset
-                            alt=`${alias}`
-                            class="node-list__image"
-                            lazyload=true
-                          />
-                        </marko-web-link>
-                      </div>
-                    </div>
+                    <site-home-section-list-block alias=sectionAlias/>
                   </div>
                 </for>
               </div>
             </div>
-          </@section>
-          <@section|{ blockName, section, aliases }| modifiers=[
-            "break-container",
-          ]>
-            <global-partners-block title="Titanium Partners"/>
-          </@section>
-          <@section>
-            <theme-section-list-deck-block aliases=[
-              "equipment",
-              "technology",
-              "workwear",
-            ]/>
           </@section>
           <!-- <@section>
             <global-node-carousel-block title="IronPros TV" with-teaser=true query-params={ contentTypes: ["Product"], limit: 12 } modifiers=["dark"] />

--- a/sites/ironpros.com/server/components/layouts/website-section/home.marko
+++ b/sites/ironpros.com/server/components/layouts/website-section/home.marko
@@ -59,7 +59,7 @@ $ const morePrefix = defaultValue(input.morePrefix, "More from");
             </div>
           </@section>
           <@section>
-            <div class="section-list-deck">
+            <div class="section-list-deck section-list-deck--graphical-sections">
               <div class="section-list-deck__row">
                 $ const sections = ['equipment', 'technology', 'workwear'];
                 <for|alias| of=sections>
@@ -67,7 +67,7 @@ $ const morePrefix = defaultValue(input.morePrefix, "More from");
                     <div class="node-list node-list--section-list node-list--flush-x node-list--flush-y node-list--inner-justified">
                       <div class="node-list__body">
                         <marko-web-link href=`/${alias}` title=`${alias}`>
-                          $ const src = buildImgixUrl(`https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/iron/home-section-icons/${alias}.png`, { w: 300 });
+                          $ const src = buildImgixUrl(`https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/iron/home-section-icons/${alias}.png`, { w: 600 });
                           $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
                           <marko-web-img
                             src=src

--- a/sites/ironpros.com/server/styles/components/_company-page.scss
+++ b/sites/ironpros.com/server/styles/components/_company-page.scss
@@ -39,6 +39,7 @@
           background-color: $white;
           img {
             margin-right: initial;
+            width: 100%;
           }
           @include media-breakpoint-down(sm) {
             margin-top: -50px;

--- a/sites/ironpros.com/server/styles/components/_home-graphical-section.scss
+++ b/sites/ironpros.com/server/styles/components/_home-graphical-section.scss
@@ -1,22 +1,26 @@
 .section-list-deck {
   &--graphical-sections {
-    .node-list {
-      &--section-list {
-        .node-list__body {
-          max-width: 320px;
-          width: 100%;
-          aspect-ratio: 407 / 562;
-          margin-left: auto;
-          margin-right: auto;
-          img {
-            width: 100%;
-          }
-        }
+    .section-list__logo-link {
+      background-color: $primary;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border-radius: 50%;
+      margin: 60px;
+
+      .section-list__logo {
+        max-width: 100%;
+        padding: 10%;
+        aspect-ratio: 1 / 1;
+        filter: brightness(0) invert(1);
       }
-      &__body {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+    }
+    .node-list--section-list .node-list__header {
+      .section-list__website-section-description {
+        @include skin-typography($style: "teaser-text-1");
+        @include marko-web-node-list-border(border-bottom);
+        padding-bottom: map-get($spacers, block);
+        text-align: center;
       }
     }
   }

--- a/sites/ironpros.com/server/styles/components/_home-graphical-section.scss
+++ b/sites/ironpros.com/server/styles/components/_home-graphical-section.scss
@@ -1,0 +1,23 @@
+.section-list-deck {
+  &--graphical-sections {
+    .node-list {
+      &--section-list {
+        .node-list__body {
+          max-width: 320px;
+          width: 100%;
+          aspect-ratio: 407 / 562;
+          margin-left: auto;
+          margin-right: auto;
+          img {
+            width: 100%;
+          }
+        }
+      }
+      &__body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+    }
+  }
+}

--- a/sites/ironpros.com/server/styles/index.scss
+++ b/sites/ironpros.com/server/styles/index.scss
@@ -66,6 +66,7 @@ $skin-font-family-secondary: "Open Sans", open-sans-fallback, sans-serif;
 
 @import "@parameter1/base-cms-marko-web-photoswipe/scss/main";
 
+@import "./components/home-graphical-section";
 @import "./components/welcome-box";
 @import "./components/site-navbar";
 @import "./components/site-menu";
@@ -75,8 +76,14 @@ $skin-font-family-secondary: "Open Sans", open-sans-fallback, sans-serif;
 
 .page-wrapper {
   $self: &;
+  &--break-container {
+    margin-left: -20px;
+    margin-right: -20px;
+  }
   > #{ $self }__section {
     &--break-container {
+      margin-right: -20px;
+      margin-left: -20px;
       @media (min-width: $marko-web-document-container-max-width) {
         margin-left: calc(-50vw - -630px);
         margin-right: calc(-50vw - -630px);


### PR DESCRIPTION
This is how it currectly will look:

![withoutIronProsTv](https://github.com/parameter1/ac-business-media-websites/assets/3845869/cd660df3-2e19-424f-875a-5e5a1a9387b5)


I am still looking into adding the IronProsTV block with the ability to break up the page some how, depending on the groups input.  I have not finished stylizing this block :) 
![withIronProsTV](https://github.com/parameter1/ac-business-media-websites/assets/3845869/242b58f5-1862-4a32-b1d7-6506dfb3d867)
