### PR TITLE
Redirect Balluun long company paths

### DIFF
--- a/sites/ironpros.com/server/routes/index.js
+++ b/sites/ironpros.com/server/routes/index.js
@@ -1,3 +1,4 @@
+const { asyncRoute } = require('@parameter1/base-cms-utils');
 const directory = require('@ac-business-media/package-global/routes/directory');
 const nativeX = require('@ac-business-media/package-global/routes/native-x');
 const home = require('./home');
@@ -8,6 +9,17 @@ const specs = require('./specs');
 const directoryTemplate = require('../templates/directory/index');
 
 module.exports = (app) => {
+  /**
+   * Redirect the Baluun long path to the short path
+   * short path should be redirected to the correct new URL
+   */
+  app.use(asyncRoute(async (req, res, next) => {
+    const { path: p } = req;
+    if (p.match(/^\/(en-us|company)/) && p.match(/\/company\/[a-z0-9]{32}\/.+?\/[a-z0-9]{32}$/)) {
+      res.redirect(301, p.replace(/\/[a-z0-9]{32}$/, ''));
+    }
+    return next();
+  }));
   // Homepage
   home(app);
 


### PR DESCRIPTION
Example: `/en-us/company/f36b2720da7963a149d640f857be4f2f/elecosoft/f0e6a957c7f617d39044fa9000e63eab` should first go to `/en-us/company/f36b2720da7963a149d640f857be4f2f/elecosoft` which will then go to `/22895149` which will finally go to `/home/company/22895149/elecosoft` resulting in the following page:

![image](https://github.com/parameter1/ac-business-media-websites/assets/46794001/f47fdf59-639d-4c62-a93c-cf7ed9e208e9)
