### PR TITLE
Update cofig contacts & setup new contact us section with form

### DIFF
--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -1,3 +1,4 @@
+import ContactUs from '@parameter1/base-cms-marko-web-contact-us/browser';
 import GCSE from '@parameter1/base-cms-marko-web-gcse/browser';
 import MonoRail from '@parameter1/base-cms-marko-web-theme-monorail/browser';
 import Leaders from '@parameter1/base-cms-marko-web-leaders/browser';
@@ -13,6 +14,7 @@ export default (Browser) => {
   const { EventBus } = Browser;
   GCSE(Browser);
   MonoRail(Browser);
+  ContactUs(Browser);
   Leaders(Browser);
   Browser.register('GlobalSpecGuideTable', GlobalSpecGuideTable);
   Browser.register('DynamicSiteMenuPositioner', DynamicSiteMenuPositioner);

--- a/packages/global/components/layouts/website-section/contact-us.marko
+++ b/packages/global/components/layouts/website-section/contact-us.marko
@@ -1,0 +1,150 @@
+import convert from "@parameter1/base-cms-marko-web-native-x/utils/convert-story-to-content";
+import { getAsArray } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { pagination: p, nativeX: nxConfig, site } = out.global;
+
+$ const { id, alias, name, pageNode } = input;
+$ const withNativeX = defaultValue(input.withNativeX, true);
+$ const sections = getAsArray(input, "sections");
+$ const perPage = 24;
+$ const withAds = alias === "premium-content" ? false : defaultValue(input.withAds, true);
+
+<global-website-section-default-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+  with-ads=withAds
+>
+  <@head>
+    <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
+      <theme-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        path=alias
+        as-rels=true
+      />
+    </theme-section-feed-block>
+  </@head>
+
+  <@section|{ blockName, section, aliases }|>
+    <theme-website-section-breadcrumbs
+      section=section
+      display-home=false
+      display-self=false
+      modifiers=["website-section"]
+    />
+
+    <if(input.beforeName)>
+      <${input.beforeName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+
+    <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
+      <if(p.page > 1)>${value}: Page ${p.page}</if>
+      <else>${value}</else>
+    </marko-web-website-section-name>
+
+    <if(input.afterName)>
+      <${input.afterName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+
+    $ const pageDetails = site.getAsObject("pageDetails");
+    <if(pageDetails[alias])>
+      <global-page-details-block content=pageDetails[alias] />
+    </if>
+    <else>
+      <marko-web-website-section-description obj=section />
+    </else>
+    <if(alias !== "premium-content" || !nxConfig.domainName)>
+      <global-section-feed-wrapper
+        aliases=aliases
+        alias=alias
+        flow=input.feedFlow
+        with-ads=withAds
+        query-params=input.queryParams
+        above-the-fold=true
+        ad-name=input.adName
+      >
+        <@node ...input.node />
+        <if(withNativeX)>
+          <@native-x index=[1] name="premium-content" aliases=aliases sectionName="Premium Content" />
+        </if>
+        <@rail>
+          <contact-us-form config-name="notificationDefaults" title=title />
+        </@rail>
+        <@rail/>
+      </global-section-feed-wrapper>
+    </if>
+    <else>
+      <div class="row">
+        <div class="col-lg-8">
+          <marko-web-native-x-publisher-stories|{ nodes, pageInfo }|
+            domain-name=nxConfig.domainName
+          >
+            <marko-web-node-list
+              inner-justified=true
+              flush-x=true
+              flush-y=false
+              modifiers=["section-feed"]
+            >
+              <@nodes nodes=nodes>
+                <@slot|{ node }|>
+                  <theme-section-feed-content-node
+                    node=convert(node)
+                    display-image=true
+                    with-section=false
+                    lazyload=false
+                    with-dates=true
+                    ...input.node
+                  />
+                </@slot>
+              </@nodes>
+            </marko-web-node-list>
+          </marko-web-native-x-publisher-stories>
+        </div>
+        <div class="col-lg-4">
+          <marko-web-identity-x-context|{ hasUser }|>
+            <if(!hasUser)>
+              <div class="sticky-top mb-block">
+                <global-identity-x-newsletter-form-inline with-image=false type="inlineContent" />
+              </div>
+            </if>
+          </marko-web-identity-x-context>
+          <div class="mb-block">
+            <if(withAds)>
+              <theme-gam-define-display-ad
+                name="top-rotation"
+                position="section_page"
+                aliases=["premium-content"]
+                modifiers=["max-width-300", "center", "margin-auto-x", "rail"]
+                class="mb-0"
+              />
+            </if>
+            <else>
+              <theme-client-side-most-popular-list-block class="sticky-top" />
+            </else>
+          </div>
+        </div>
+      </div>
+    </else>
+  </@section>
+
+  <for|s| of=sections>
+    <@section|{ blockName, section, aliases }| modifiers=s.modifiers>
+      <${s.renderBody}
+        block-name=blockName
+        section=section
+        aliases=aliases
+      />
+    </@section>
+  </for>
+</global-website-section-default-layout>

--- a/packages/global/components/layouts/website-section/marko.json
+++ b/packages/global/components/layouts/website-section/marko.json
@@ -60,6 +60,20 @@
     "@node": "object",
     "@with-ads": "boolean"
   },
+  "<global-website-section-contact-us-layout>": {
+    "template": "./contact-us.marko",
+    "@sections <section>[]": {},
+    "<before-name>": {},
+    "<after-name>": {},
+    "@feed-flow": "object",
+    "@id": "number",
+    "@ad-name": "string",
+    "@alias": "string",
+    "@name": "string",
+    "@page-node": "object",
+    "@node": "object",
+    "@with-ads": "boolean"
+  },
   "<global-website-section-home-layout>": {
     "template": "./home.marko",
     "<head>": {},

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -18,6 +18,7 @@
     "@parameter1/base-cms-inflector": "^4.5.12",
     "@parameter1/base-cms-marko-core": "^4.55.4",
     "@parameter1/base-cms-marko-web": "^4.55.4",
+    "@parameter1/base-cms-marko-web-contact-us": "^4.40.3",
     "@parameter1/base-cms-marko-web-deferred-script-loader": "^4.40.3",
     "@parameter1/base-cms-marko-web-gam": "^4.55.1",
     "@parameter1/base-cms-marko-web-gcse": "^4.40.3",

--- a/packages/global/routes/redirects.js
+++ b/packages/global/routes/redirects.js
@@ -1,5 +1,1 @@
-module.exports = (app) => {
-  app.get('/:alias(contact-us|about-us|contact-our-staff)', (req, res) => {
-    res.redirect(301, '/page/contact-us');
-  });
-};
+module.exports = () => {};

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -3,6 +3,7 @@ const { startServer } = require('@parameter1/base-cms-marko-web');
 const { set, get, getAsObject } = require('@parameter1/base-cms-object-path');
 const loadInquiry = require('@parameter1/base-cms-marko-web-inquiry');
 const htmlSitemapPagination = require('@parameter1/base-cms-marko-web-html-sitemap/middleware/paginated');
+const contactUsHandler = require('@parameter1/base-cms-marko-web-contact-us');
 const identityX = require('@parameter1/base-cms-marko-web-identity-x');
 const omedaIdentityX = require('@parameter1/base-cms-marko-web-omeda-identity-x');
 
@@ -19,6 +20,8 @@ const recaptcha = require('./config/recaptcha');
 const idxNavItems = require('./config/identity-x-nav');
 
 const routes = (siteRoutes, siteConfig) => (app) => {
+  // load contact us route /__contact-us
+  contactUsHandler(app);
   // Handle submissions on /__inquiry
   loadInquiry(app);
   // Shared/global routes (all sites)

--- a/packages/global/templates/website-section/contact-us.marko
+++ b/packages/global/templates/website-section/contact-us.marko
@@ -1,0 +1,8 @@
+$ const { id, alias, name, pageNode } = input;
+
+<global-website-section-contact-us-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+/>

--- a/sites/ironpros.com/config/site.js
+++ b/sites/ironpros.com/config/site.js
@@ -71,7 +71,7 @@ module.exports = {
   contactUs: {
     title: 'Submit a comment.',
     notificationDefaults: {
-      to: 'brian@parameter1.com',
+      to: 'sales@ironpros.com',
       branding: {
         logo: 'https://img.ironpros.com/files/base/acbm/fcp/image/static/logo/ironpros-logo-white.png?h=45&auto=format,compress&bg=000000&pad=5',
       },
@@ -79,7 +79,7 @@ module.exports = {
         email: 'support@ironpros.com',
       },
     },
-    to: 'brian@parameter1.com',
+    to: 'sales@ironpros.com',
     branding: {
       logo: 'https://img.ironpros.com/files/base/acbm/fcp/image/static/logo/ironpros-logo-white.png?h=45&auto=format,compress&bg=000000&pad=5',
     },

--- a/sites/ironpros.com/config/site.js
+++ b/sites/ironpros.com/config/site.js
@@ -63,9 +63,9 @@ module.exports = {
   inquiry: {
     enabled: true,
     directSend: true,
-    sendTo: 'requestmoreinfo@acbusinessmedia.com',
-    sendFrom: 'IronsPros.com <noreply@parameter1.com>',
-    logo: 'https://img.ironpros.com/files/base/acbm/fcp/image/static/logo/ironpros-logo-white.png?h=45&auto=format,compress&bg=000000&pad=5',
+    sendTo: 'sales@ironpros.com',
+    sendFrom: 'IronsPros.com <noreply@ironpros.com>',
+    logo: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/ironpros-logo-white.png?h=45&auto=format,compress&bg=000000&pad=5',
     bgColor: '#000',
   },
   pageDetails,

--- a/sites/ironpros.com/config/site.js
+++ b/sites/ironpros.com/config/site.js
@@ -68,6 +68,25 @@ module.exports = {
     logo: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/ironpros-logo-white.png?h=45&auto=format,compress&bg=000000&pad=5',
     bgColor: '#000',
   },
+  contactUs: {
+    title: 'Submit a comment.',
+    notificationDefaults: {
+      to: 'brian@parameter1.com',
+      branding: {
+        logo: 'https://img.ironpros.com/files/base/acbm/fcp/image/static/logo/ironpros-logo-white.png?h=45&auto=format,compress&bg=000000&pad=5',
+      },
+      support: {
+        email: 'support@ironpros.com',
+      },
+    },
+    to: 'brian@parameter1.com',
+    branding: {
+      logo: 'https://img.ironpros.com/files/base/acbm/fcp/image/static/logo/ironpros-logo-white.png?h=45&auto=format,compress&bg=000000&pad=5',
+    },
+    support: {
+      email: 'support@ironpros.com',
+    },
+  },
   pageDetails,
   search,
 };

--- a/sites/ironpros.com/package.json
+++ b/sites/ironpros.com/package.json
@@ -36,6 +36,7 @@
     "@ac-business-media/package-global": "^2.9.2",
     "@parameter1/base-cms-marko-core": "^4.55.4",
     "@parameter1/base-cms-marko-web": "^4.55.4",
+    "@parameter1/base-cms-marko-web-contact-us": "^4.40.3",
     "@parameter1/base-cms-marko-web-gtm": "^4.40.3",
     "@parameter1/base-cms-marko-web-icons": "^4.36.8",
     "@parameter1/base-cms-marko-web-identity-x": "^4.51.2",

--- a/sites/ironpros.com/server/components/layouts/website-section/contact-us.marko
+++ b/sites/ironpros.com/server/components/layouts/website-section/contact-us.marko
@@ -1,0 +1,93 @@
+import convert from "@parameter1/base-cms-marko-web-native-x/utils/convert-story-to-content";
+import { getAsArray } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { pagination: p, nativeX: nxConfig, site } = out.global;
+
+$ const { id, alias, name, pageNode } = input;
+$ const withNativeX = defaultValue(input.withNativeX, true);
+$ const sections = getAsArray(input, "sections");
+$ const perPage = 24;
+$ const withAds = false;
+
+<global-website-section-default-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+  with-ads=withAds
+>
+  <@head>
+    <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
+      <theme-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        path=alias
+        as-rels=true
+      />
+    </theme-section-feed-block>
+  </@head>
+
+  <@section|{ blockName, section, aliases }|>
+    <theme-website-section-breadcrumbs
+      section=section
+      display-home=false
+      display-self=false
+      modifiers=["website-section"]
+    />
+
+    <if(input.beforeName)>
+      <${input.beforeName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+
+    <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
+      <if(p.page > 1)>${value}: Page ${p.page}</if>
+      <else>${value}</else>
+    </marko-web-website-section-name>
+
+    <if(input.afterName)>
+      <${input.afterName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+
+    $ const pageDetails = site.getAsObject("pageDetails");
+    <if(pageDetails[alias])>
+      <global-page-details-block content=pageDetails[alias] />
+    </if>
+    <else>
+      <marko-web-website-section-description obj=section />
+    </else>
+      <global-section-feed-wrapper
+        aliases=aliases
+        alias=alias
+        flow=input.feedFlow
+        with-ads=withAds
+        query-params=input.queryParams
+        above-the-fold=true
+        ad-name=input.adName
+      >
+        <@node ...input.node />
+        <@rail>
+          <contact-us-form config-name="notificationDefaults" title=site.get('contactUs.title') />
+        </@rail>
+        <@rail/>
+      </global-section-feed-wrapper>
+  </@section>
+
+  <for|s| of=sections>
+    <@section|{ blockName, section, aliases }| modifiers=s.modifiers>
+      <${s.renderBody}
+        block-name=blockName
+        section=section
+        aliases=aliases
+      />
+    </@section>
+  </for>
+</global-website-section-default-layout>

--- a/sites/ironpros.com/server/components/layouts/website-section/marko.json
+++ b/sites/ironpros.com/server/components/layouts/website-section/marko.json
@@ -26,6 +26,20 @@
     "@with-native-x": "boolean",
     "@query-params": "object"
   },
+  "<site-website-section-contact-us-layout>": {
+    "template": "./contact-us.marko",
+    "@sections <section>[]": {},
+    "<before-name>": {},
+    "<after-name>": {},
+    "@feed-flow": "object",
+    "@id": "number",
+    "@ad-name": "string",
+    "@alias": "string",
+    "@name": "string",
+    "@page-node": "object",
+    "@node": "object",
+    "@with-ads": "boolean"
+  },
   "<site-website-section-home-layout>": {
     "template": "./home.marko",
     "<head>": {},

--- a/sites/ironpros.com/server/routes/website-section.js
+++ b/sites/ironpros.com/server/routes/website-section.js
@@ -1,9 +1,14 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ac-business-media/package-global/graphql/fragments/website-section-with-cover-image-page');
+const contactUs = require('../templates/website-section/contact-us');
 const webinars = require('../templates/website-section/webinars');
 const section = require('../templates/website-section');
 
 module.exports = (app) => {
+  app.get('/:alias(contact-us)', withWebsiteSection({
+    template: contactUs,
+    queryFragment,
+  }));
   app.get('/:alias(webinars)', withWebsiteSection({
     template: webinars,
     queryFragment,

--- a/sites/ironpros.com/server/templates/website-section/contact-us.marko
+++ b/sites/ironpros.com/server/templates/website-section/contact-us.marko
@@ -1,0 +1,8 @@
+$ const { id, alias, name, pageNode } = input;
+
+<site-website-section-contact-us-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+/>


### PR DESCRIPTION
Added global version with IP overwritten contact us layout template with 24 items vs 12 to hopefully only ever get one page.  Added IP site override to remove ad calls too. 