### PR TITLE
Remove home section specific css override.

### DIFF
--- a/sites/ironpros.com/server/styles/components/_page-cover-image.scss
+++ b/sites/ironpros.com/server/styles/components/_page-cover-image.scss
@@ -82,10 +82,6 @@
 .page {
   &--website-section-87716 {
     .page-cover-image {
-      &__wrapper {
-        background-image: url('https://img.ironpros.com/files/base/acbm/fcp/image/static/logo/iron/section-headers/ip-home.png');
-        background-position: center;
-      }
       &__contents {
         text-align: center;
         .page-wrapper__website-section-name,


### PR DESCRIPTION
Allow it for use default or out of manage

<img width="2146" alt="Screenshot 2024-05-13 at 9 30 37 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/dc55e026-c8b6-4997-8fa1-8471557d98cb">
