### PR TITLE
Add activeCustomFields to idx in refresh theme

### DIFF
--- a/packages/refresh-theme/config/identity-x.js
+++ b/packages/refresh-theme/config/identity-x.js
@@ -18,6 +18,7 @@ module.exports = ({
     'postalCode',
   ],
   gtmUserFields,
+  activeCustomFieldIds = [],
   defaultFieldLabels = {
     mobileNumber: 'Mobile Phone *',
   },
@@ -27,6 +28,7 @@ module.exports = ({
     apiToken: process.env.IDENTITYX_API_TOKEN,
     hiddenFields,
     requiredServerFields,
+    activeCustomFieldIds,
     requiredClientFields,
     gtmUserFields,
     defaultFieldLabels,

--- a/sites/forconstructionpros.com/config/identity-x.js
+++ b/sites/forconstructionpros.com/config/identity-x.js
@@ -2,4 +2,7 @@ const configureIdentityX = require('@ac-business-media/refresh-theme/config/iden
 
 module.exports = configureIdentityX({
   appId: '5e28a2d858e67b162e55ae3b',
+  activeCustomFieldIds: [
+    '',
+  ],
 });


### PR DESCRIPTION
Allow for passing of activeCustom Fields in the refresh theme and set the fcp site to have an empty active value in order to prevent new custom questions from showing.

<img width="1254" alt="Screenshot 2024-05-14 at 9 34 11 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/22fd51c7-7021-4fde-8a55-4bbc6527a465">
