### PR TITLE
Add css style for tv on ironpros tv landing page

### DIFF
--- a/sites/ironpros.com/server/styles/index.scss
+++ b/sites/ironpros.com/server/styles/index.scss
@@ -135,3 +135,11 @@ $theme-section-header-font: $theme-header-font-family;
     height: 60px;
   }
 }
+
+.page--content-21136085 {
+  .page-wrapper__content-name {
+    b {
+      color: $secondary;
+    }
+  }
+}


### PR DESCRIPTION
I eneded up adding a <b> around tv within management to be able to select TV to apply secondary color

<img width="1272" alt="Screenshot 2024-05-22 at 8 08 59 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/7e1f6ba1-5ed9-4a74-a17f-4d2096ace4bb">
