### PR TITLE
Adjust section toc styling

### DIFF
--- a/sites/ironpros.com/server/styles/components/_section-toc.scss
+++ b/sites/ironpros.com/server/styles/components/_section-toc.scss
@@ -18,7 +18,28 @@
     }
   }
   &--section-list-toc {
-    @include marko-web-node-list-border(border-bottom);
-    margin-bottom: map-get($spacers, block);
+    .node__title {
+      font-family: $theme-header-font-family;
+    }
+    #{ $self }__node {
+      .node {
+        padding: map-get($spacers, 2);
+        @include marko-web-node-list-border(border-top);
+        @include marko-web-node-list-border(border-right);
+        @include marko-web-node-list-border(border-bottom);
+        @include marko-web-node-list-border(border-left);
+      }
+    }
+  }
+
+}
+
+
+.node-list {
+  $self: &;
+  --section-list-toc {
+    #{ $self }__header {
+      margin-bottom: 0;
+    }
   }
 }


### PR DESCRIPTION
Reduce spacing and adjust where borders are set to help tighten up the top TOC portion of page #1. Also update the font family being used on the toc cards

![equipement](https://github.com/parameter1/ac-business-media-websites/assets/3845869/5fc1f80c-83fc-469c-aca4-44af8af842d0)
<img width="504" alt="Screenshot 2024-05-22 at 8 42 57 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/25465418-b8eb-4f8e-a490-561f339e36e8">
<img width="555" alt="Screenshot 2024-05-22 at 8 43 09 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/ea7beba3-ffc6-4eb4-9451-0ad2c9b18387">
