### PR TITLE
Update featured node carousel to correctly handle v-if on teaser & company

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-node-defaults: &node
     - yarn-cache:/.yarn-cache
 
 x-env-defaults: &env
+  CSS_MODE: ${CSS_MODE-optimized}
   NEW_RELIC_ENABLED: ${NEW_RELIC_ENABLED-0}
   NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY-(unset)}
   NODE_ENV: development

--- a/packages/global/browser/node-carousel.vue
+++ b/packages/global/browser/node-carousel.vue
@@ -37,15 +37,15 @@
                   {{ node.shortName }}
                 </h5>
                 <div
-                  :v-if="withTeaser"
+                  v-if="withTeaser"
                   class="node__teaser">
                   {{ node.teaser }}
                 </div>
               </div>
             </a>
             <a
+              v-if="withCompany"
               :href="node.company.canonicalPath"
-              :v-if="withCompany"
               class="node__company"
             >
               {{ node.company.name }}

--- a/sites/ironpros.com/server/components/blocks/titanium-product-carousel.marko
+++ b/sites/ironpros.com/server/components/blocks/titanium-product-carousel.marko
@@ -6,6 +6,9 @@ import loadTitaniumCompanyProducts from "../../loaders/titanium-company-products
 $ const withViewMore = defaultValue(input.withViewMore, true);
 $ const { title = "Featured Products", sectionId } = input;
 $ const { apollo } = out.global;
+$ const withTeaser =  defaultValue(input.withTeaser, false);
+
+$ console.log(withTeaser)
 
 $ const blockName = "node-carousel";
 $ const modifiers = ["titanium-products", ...getAsArray(input, "modifiers")];
@@ -35,7 +38,7 @@ $ const promise = loadTitaniumCompanyProducts(apollo, {
           name="GlobalNodeCarousel"
           props={
             nodes,
-            withTeaser: input.withTeaser,
+            withTeaser,
             withCompany: true,
           }
           ssr=true

--- a/sites/ironpros.com/server/components/layouts/content/company.marko
+++ b/sites/ironpros.com/server/components/layouts/content/company.marko
@@ -285,7 +285,7 @@ $ const displayInquiry = (content) => {
             flush-x=false
             class="mt-block"
           >
-            <@node with-dates=false />
+            <@node with-dates=false with-teaser=true />
           </theme-latest-content-list-block>
 
           <!-- <theme-content-card-deck-block

--- a/sites/ironpros.com/server/styles/components/_titanium-products.scss
+++ b/sites/ironpros.com/server/styles/components/_titanium-products.scss
@@ -3,7 +3,7 @@
     .node__contents .node__body--carousel {
       padding-bottom: 0;
       .node__title {
-        -webkit-line-clamp: 2;
+        -webkit-line-clamp: 3;
         height: 5ex;
         -webkit-box-orient: vertical;
         display: -webkit-box;


### PR DESCRIPTION
This was brought to light when trying to add teaser to product for IronPros.  Prior to running this cleanup I will need to deploy this to prevent the featured product block from not looking right... showing teasers. 

new page look post this and script run for generating product tasers:
![directory](https://github.com/parameter1/ac-business-media-websites/assets/3845869/9b453972-4668-4b3e-b4dc-84869b51cfd6)
