### PR TITLE
Disable inbody leaderboard allowing GTM teads inject

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -201,6 +201,9 @@ $ const loadMore = !showOverlay; // && !idxFormId;
                   block-name=blockName
                   selector=bodyId
                   preventHTMLInjection=!shouldInjectAds
+                  // disable leadderboard ad inject to allow for Teads video injection from GTM
+                  desktop-leaderboard-ad-counts=[]
+                  mobile-leaderboard-ad-counts=[]
                 />
 
                 $ const transcriptId = `content-transcript-${content.id}`;

--- a/packages/global/components/layouts/content/sponsored.marko
+++ b/packages/global/components/layouts/content/sponsored.marko
@@ -106,6 +106,9 @@ $ const shouldInjectAds = false;
                   selector=bodyId
                   preventHTMLInjection=!shouldInjectAds
                   lazyload-first-image=lazyloadFirstImage
+                  // disable leadderboard ad inject to allow for Teads video injection from GTM
+                  desktop-leaderboard-ad-counts=[]
+                  mobile-leaderboard-ad-counts=[]
                 />
                 <if(content.transcript)>
                   $ const transcriptId = `content-transcript-${content.id}`;


### PR DESCRIPTION
### DEV:
<img width="712" alt="Screenshot 2024-05-29 at 11 17 39 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/7895d589-df43-4d52-94ed-46ec6eb88999">

### Current version with leaderboard:

<img width="464" alt="Screenshot 2024-05-29 at 11 18 08 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/2efe96fd-6574-426e-a54e-15bec1b5db62">
