### PR TITLE
Update node carousel and call with image opt support

### DIFF
--- a/packages/global/browser/node-carousel.vue
+++ b/packages/global/browser/node-carousel.vue
@@ -22,8 +22,8 @@
                 :data-src="getImgSrc(node.primaryImage.src)"
                 :data-srcset="[getImgSrcSet(node.primaryImage.src)]"
                 :alt="node.shortName"
-                width="250"
-                height="140"
+                :width="imageOptions.w"
+                :height="imageOptions.h"
               >
             </a>
             <a
@@ -76,6 +76,14 @@ export default {
       type: Boolean,
       default: false,
     },
+    imageOptions: {
+      type: Object,
+      default: () => ({
+        fit: 'crop',
+        w: 250,
+        h: 140,
+      }),
+    },
   },
 
   data: () => ({
@@ -118,11 +126,20 @@ export default {
   }),
 
   methods: {
+    getImagePath(imagePath, withDpr = false) {
+      const imageParams = new URLSearchParams({
+        ...this.imageOptions,
+      });
+      const src = imagePath.split('?')[0];
+      return withDpr
+        ? `${src}?${imageParams.toString()}&dpr=2 2x`
+        : `${src}?${imageParams.toString()}`;
+    },
     getImgSrc(imagePath) {
-      return `${imagePath}?auto=format%2Ccompress&fit=crop&h=140&q=70&w=250`;
+      return this.getImagePath(imagePath, false);
     },
     getImgSrcSet(imagePath) {
-      return `${imagePath}?auto=format%2Ccompress&fit=crop&h=140&q=70&w=250&dpr=2 2x`;
+      return this.getImagePath(imagePath, true);
     },
   },
 };

--- a/sites/ironpros.com/server/components/blocks/titanium-product-carousel.marko
+++ b/sites/ironpros.com/server/components/blocks/titanium-product-carousel.marko
@@ -38,6 +38,12 @@ $ const promise = loadTitaniumCompanyProducts(apollo, {
             nodes,
             withTeaser,
             withCompany: true,
+            imageOptions: {
+              h: 140,
+              w: 250,
+              fit: 'fillmax',
+              fill: 'solid',
+            }
           }
           ssr=true
         />


### PR DESCRIPTION
Allows for image opt to be passed into the carousel.

Default is :
```js
{
  h: 140,
  w: 250,
  fit: 'fillmax',
  fill: 'solid',
}
```

<img width="1348" alt="image" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/47b4f917-86f9-4797-98b6-e92ac0f109ef">
