### PR TITLE
Add Page title & description support to promo layout

### DIFF
--- a/packages/global/templates/website-section/promo-cards.marko
+++ b/packages/global/templates/website-section/promo-cards.marko
@@ -4,7 +4,7 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 import promotionQueryFragment from "../../graphql/fragments/content-promotion-list";
 
-$ const { GAM } = out.global;
+$ const { GAM, site } = out.global;
 
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
@@ -42,6 +42,24 @@ $ const pageWrapperModifiers = defaultValue(input.pageWrapperModifiers, []);
             />
           </@section>
         </if>
+
+        <@section|{ blockName }|>
+          <theme-website-section-breadcrumbs
+            section=section
+            display-home=false
+            display-self=false
+            modifiers=["website-section"]
+          />
+          <marko-web-website-section-name tag="h1" block-name=blockName obj=section />
+
+          $ const pageDetails = site.getAsObject("pageDetails");
+          <if(pageDetails[alias])>
+            <global-page-details-block content=pageDetails[alias] />
+          </if>
+          <else>
+            <marko-web-website-section-description obj=section />
+          </else>
+        </@section>
 
 
         <@section modifiers=["card-deck"]>


### PR DESCRIPTION
<img width="1522" alt="Screenshot 2024-06-04 at 8 46 03 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/7f2a91d1-18e5-4d81-99e8-a6fa928f32d7">
<img width="1682" alt="Screenshot 2024-06-04 at 8 46 11 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/7ac09951-d228-4916-a8e2-1efa0e680f87">
