### PR TITLE
Add layout/route support for full width "Premium" content

### DIFF
--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -103,6 +103,20 @@ $ const withAds = alias === "premium-content" ? false : defaultValue(input.withA
         </@rail>
       </global-section-feed-wrapper>
     </if>
+    <else-if(alias === "premium-content")>
+      <global-section-feed-wrapper
+        aliases=aliases
+        alias=alias
+        flow=input.feedFlow
+        with-ads=withAds
+        query-params=input.queryParams
+        above-the-fold=true
+        ad-name=input.adName
+        no-rail=true
+      >
+        <@node ...input.node />
+      </global-section-feed-wrapper>
+    </else-if>
     <else>
       <div class="row">
         <div class="col-lg-8">

--- a/packages/global/components/wrappers/marko.json
+++ b/packages/global/components/wrappers/marko.json
@@ -18,7 +18,8 @@
     "@node": "object",
     "@node-list": "object",
     "@path": "string",
-    "@above-the-fold": "boolean"
+    "@above-the-fold": "boolean",
+    "@no-rail": "boolean"
   },
   "<global-native-x-section-feed-wrapper>": {
     "template": "./native-x-section-feed.marko"

--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -7,7 +7,7 @@ $ const withPagination = defaultValue(input.withPagination, true);
 $ const perPage = 12;
 $ const skip = p.skip({ perPage });
 
-$ const { modifiers } = input;
+$ const { noRail, modifiers } = input;
 $ const path = input.path || input.alias || req.path;
 $ const withAds = GAM ? defaultValue(input.withAds, true) : false;
 $ const aboveTheFold = defaultValue(input.aboveTheFold, false);
@@ -71,6 +71,41 @@ $ const params = { ...queryParams, limit, skip };
       </div>
     </div>
   </if>
+  <else-if(noRail)>
+    <div class="row">
+      <div class="col-lg-12">
+        <for|nodeGroup, index| of=nodeGroups>
+          $ const isLast = index === nodeGroups.length - 1;
+          $ const header = index === 0 ? input.header : null;
+          $ const adName = index === 0 ? input.adName || "top-rotation" : input.adName || "rotation";
+          $ const flowInput = (index === 0 && aboveTheFold) ? { ...input.flow, lazyload: false } : input.flow;
+          $ const nativeX = index === 0 ? input.nativeX : undefined;
+          <section-feed-flow
+            nodes=nodeGroup
+            header=header
+            modifiers=modifiers
+            node=input.node
+            node-list=input.nodeList
+            aliases=input.aliases
+            flow=flowInput
+            with-ads=withAds
+            ad-name=adName
+            native-x=nativeX
+          />
+        </for>
+        <if(withPagination)>
+          <theme-section-feed-block|{ totalCount }| alias=input.alias query-name=queryName count-only=true>
+            <@query-params ...queryParams />
+            <theme-pagination-controls
+              per-page=limit
+              total-count=totalCount
+              path=path
+            />
+          </theme-section-feed-block>
+        </if>
+      </div>
+    </div>
+  </else-if>
   <else>
     $ const topNodeGroups = nodeGroups.slice(0, 2);
     $ const bottomNodeGroups = nodeGroups.slice(2);

--- a/sites/forconstructionpros-global.com/server/styles/index.scss
+++ b/sites/forconstructionpros-global.com/server/styles/index.scss
@@ -73,3 +73,17 @@ $info: #6c757d;
     }
   }
 }
+
+
+
+
+body .document-container > .page--website-section-77798:first-of-type,
+body .document-container > .page--website-section-57411:first-of-type,
+body .document-container > .page--website-section-85252:first-of-type,
+body .document-container > .page--website-section-86540:first-of-type,
+body .document-container > .page--website-section-81549:first-of-type,
+body .document-container > .page--spec-guide-index:first-of-type,
+body .document-container > .page--spec-guide:first-of-type,
+body .document-container > .page--without-ads:first-of-type  {
+  margin-top: 0;
+}


### PR DESCRIPTION
This is not a nativeX route, but rather scheduled content to a premium section, ie paid content.  Also add css support to remove white space at the top of section not firing ads.  

@todo work with the group to also ad a description to help with the look of the top of this page or look at adding specific styling....
<img width="1573" alt="Screenshot 2024-06-04 at 9 29 50 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/2361fc48-f386-4a6b-a20f-4046cb71121c">



other withoutAds examples:
<img width="1736" alt="Screenshot 2024-06-04 at 9 29 22 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/f19680cd-be2b-4407-a5e2-55e4dc1f34dd">
<img width="1557" alt="Screenshot 2024-06-04 at 9 29 39 AM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/fd7f4ba8-56b1-4c30-aea1-f14f1bdf42ee">



