### PR TITLE
Add Credspark target container to default content layout

### DIFF
--- a/packages/global/components/layouts/content/contact.marko
+++ b/packages/global/components/layouts/content/contact.marko
@@ -39,6 +39,8 @@ $ const perPage = 12;
 
         <default-theme-page-contents|{ blockName }| modifiers=["contact"]>
           <marko-web-content-body block-name=blockName obj=content />
+
+          <div id="credspark-container" />
         </default-theme-page-contents>
 
       </marko-web-element>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -250,8 +250,6 @@ $ const loadMore = !showOverlay; // && !idxFormId;
                   </for>
                 </if>
 
-                <div id="credspark-container" />
-
                 <if(displayReadNext)>
                   <theme-read-next-block
                     content-id=id
@@ -273,6 +271,8 @@ $ const loadMore = !showOverlay; // && !idxFormId;
                     <identity-x-newsletter-form-inline type="inlineContent" with-image=true />
                   </if>
                 </marko-web-identity-x-context>
+
+                <div id="credspark-container" />
               </else>
             </marko-web-identity-x-access>
 

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -250,6 +250,8 @@ $ const loadMore = !showOverlay; // && !idxFormId;
                   </for>
                 </if>
 
+                <div id="credspark-container" />
+
                 <if(displayReadNext)>
                   <theme-read-next-block
                     content-id=id

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -266,13 +266,14 @@ $ const loadMore = !showOverlay; // && !idxFormId;
                   />
                 </if>
 
+                <div id="credspark-container" />
+
                 <marko-web-identity-x-context|{ hasUser }|>
                   <if(!hasUser)>
                     <identity-x-newsletter-form-inline type="inlineContent" with-image=true />
                   </if>
                 </marko-web-identity-x-context>
 
-                <div id="credspark-container" />
               </else>
             </marko-web-identity-x-access>
 

--- a/packages/global/components/layouts/content/product.marko
+++ b/packages/global/components/layouts/content/product.marko
@@ -58,8 +58,6 @@ $ const displayInquiry = (content) => {
 
             />
 
-            <div id="credspark-container" />
-
             <if(displaySocialShare)>
               <marko-web-social-sharing
                 path=content.siteContext.path
@@ -67,6 +65,8 @@ $ const displayInquiry = (content) => {
                 print-path=`/print/content/${content.id}`
               />
             </if>
+
+            <div id="credspark-container" />
           </theme-page-contents>
         </div>
       </div>

--- a/packages/global/components/layouts/content/product.marko
+++ b/packages/global/components/layouts/content/product.marko
@@ -67,6 +67,13 @@ $ const displayInquiry = (content) => {
             </if>
 
             <div id="credspark-container" />
+
+            <marko-web-identity-x-context|{ hasUser }|>
+              <if(!hasUser)>
+                <identity-x-newsletter-form-inline type="inlineContent" with-image=true />
+              </if>
+            </marko-web-identity-x-context>
+
           </theme-page-contents>
         </div>
       </div>

--- a/packages/global/components/layouts/content/product.marko
+++ b/packages/global/components/layouts/content/product.marko
@@ -55,7 +55,10 @@ $ const displayInquiry = (content) => {
               selector=bodyId
               preventHTMLInjection=true
               lazyload-first-image=false
+
             />
+
+            <div id="credspark-container" />
 
             <if(displaySocialShare)>
               <marko-web-social-sharing

--- a/packages/global/components/layouts/content/webinar.marko
+++ b/packages/global/components/layouts/content/webinar.marko
@@ -87,6 +87,8 @@ $ const sections = getAsArray(input, "sections");
               ${btnLabel}
             </marko-web-link>
 
+            <div id="credspark-container" />
+
           </theme-page-contents>
         </div>
       </div>

--- a/packages/global/components/layouts/content/whitepaper.marko
+++ b/packages/global/components/layouts/content/whitepaper.marko
@@ -40,6 +40,8 @@ $ const dateFormat = defaultValue(input.dateFormat, "MMMM D, YYYY");
               <@wufoo user-name=site.get("wufoo.userName") />
               <@link class="btn btn-primary" />
             </theme-content-download>
+
+            <div id="credspark-container" />
           </default-theme-page-contents>
         </div>
       </div>

--- a/sites/forconstructionpros-global.com/config/site.js
+++ b/sites/forconstructionpros-global.com/config/site.js
@@ -23,6 +23,9 @@ module.exports = {
   omeda,
   omedaIdentityX,
   identityXOptInHooks,
+  wufoo: {
+    userName: 'acbm',
+  },
   gcse: {
     id: '003355913687346718228:la4zrhjf2r9',
   },


### PR DESCRIPTION
This is used within gtm to place a quiz based on channel. 


<img width="984" alt="Screenshot 2024-06-04 at 1 49 35 PM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/5a2fde59-e96f-4f55-829f-68fdec15e2e3">
<img width="1028" alt="Screenshot 2024-06-04 at 1 50 20 PM" src="https://github.com/parameter1/ac-business-media-websites/assets/3845869/5980b5c3-04fc-4da1-b1ac-165c6d918264">

