### PR TITLE
Configure IDX for custom fields/demos on IronPros

### DIFF
--- a/sites/ironpros.com/config/identity-x.js
+++ b/sites/ironpros.com/config/identity-x.js
@@ -26,7 +26,6 @@ formDefault.fieldRows.push(
 );
 
 module.exports = configureIdentityX({
-  // '@TODO-Configure',
   requiredClientFields: [
     'givenName',
     'familyName',

--- a/sites/ironpros.com/config/identity-x.js
+++ b/sites/ironpros.com/config/identity-x.js
@@ -3,7 +3,51 @@ const formDefault = require('@ac-business-media/package-global/config/identity-x
 
 formDefault.anonymousCta = 'Register on IRONPROS.com to download this document, gain access to premium content, and more.';
 
+// append custom demos row of questions to the end of general questions
+formDefault.fieldRows.push(
+  [
+    // Demo: IP Business
+    {
+      label: 'Business',
+      id: '665f2a6a08a6794e28b8f0b7',
+      type: 'custom-select',
+      required: true,
+      width: 0.5,
+    },
+    // Demo: IP Job Title
+    {
+      label: 'Primary Business',
+      id: '665f2c75afc3b38193c926c0',
+      type: 'custom-select',
+      required: true,
+      width: 0.5,
+    },
+  ],
+);
+
 module.exports = configureIdentityX({
   // '@TODO-Configure',
+  requiredClientFields: [
+    'givenName',
+    'familyName',
+    'organization',
+    'organizationTitle', // @todo make this a custom field somehow
+    'regionCode', // Only require client-side for non-us/ca
+    'countryCode',
+    'postalCode', // Only require client-side for non-us/ca
+    '665f2a6a08a6794e28b8f0b7', // Business
+    '665f2c75afc3b38193c926c0', // Job Title
+  ],
   appId: '661564bda370d83993649ffc',
+  activeCustomFieldIds: [
+    '665f2a6a08a6794e28b8f0b7', // Business
+    '665f2c75afc3b38193c926c0', // Job Title
+  ],
+  forms: {
+    default: formDefault,
+  },
+  gtmUserFields: {
+    primary_business: '665f2a6a08a6794e28b8f0b7',
+    job_title: '665f2c75afc3b38193c926c0',
+  },
 });

--- a/sites/ironpros.com/config/identity-x.js
+++ b/sites/ironpros.com/config/identity-x.js
@@ -30,7 +30,6 @@ module.exports = configureIdentityX({
     'givenName',
     'familyName',
     'organization',
-    'organizationTitle', // @todo make this a custom field somehow
     'regionCode', // Only require client-side for non-us/ca
     'countryCode',
     'postalCode', // Only require client-side for non-us/ca


### PR DESCRIPTION
When clicking this piece of [this piece](https://www.ironpros.com/procurement-and-supply-chain-management/article/22908655/how-construction-procurement-software-evolution-helps-your-contracting-business) of Premium Content, even user has logged in before, they are now prompted to answer the demos recently added in IDX
<img width="1057" alt="Screenshot 2024-06-05 at 1 36 16 PM" src="https://github.com/parameter1/ac-business-media-websites/assets/64623209/8b5f0572-8072-4159-bb68-9009dead08c1">
