### PR TITLE
Adjustments to improve page performance.

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -43,11 +43,13 @@ $ const omedaConfig = site.get('omeda');
 
 
     <!-- init gam && googletag which is used in other places -->
-    <marko-web-gam-init
-      request-frame=true
-      target-tag="body"
-      on="load"
-    />
+    <if(GAM)>
+      <marko-web-gam-init
+        request-frame=true
+        target-tag="body"
+        on="load"
+      />
+    </if>
 
     <!-- init native-x -->
     <marko-web-native-x-init
@@ -73,10 +75,12 @@ $ const omedaConfig = site.get('omeda');
     <!-- start gtm -->
     <marko-web-gtm-start />
 
-    <!-- start gam -->
-    <marko-web-gam-enable>
-      <@lazy-load ...site.getAsObject("gam.lazyLoad") />
-    </marko-web-gam-enable>
+    <if(GAM)>
+      <!-- start gam -->
+      <marko-web-gam-enable>
+        <@lazy-load ...site.getAsObject("gam.lazyLoad") />
+      </marko-web-gam-enable>
+    </if>
   </@head>
   <@above-wrapper>
     <!-- Temp hack to Fix Top Leaderboard -->

--- a/packages/global/components/layouts/content/company-details/company-logo.marko
+++ b/packages/global/components/layouts/content/company-details/company-logo.marko
@@ -8,7 +8,7 @@ $ const blockName = "company-logo";
 $ const hasImage = Boolean(image.src);
 
 <if(hasImage)>
-  $ const src = buildImgixUrl(image.src, { w: 125 });
+  $ const src = buildImgixUrl(image.src, { w: 120, h: 80 });
   $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
   <marko-web-img
     src=src
@@ -16,5 +16,6 @@ $ const hasImage = Boolean(image.src);
     alt=image.alt
     class=`${blockName}__image`
     lazyload=true
+    attrs={ height: 80, width: 120 }
   />
 </if>

--- a/sites/ironpros.com/server/components/layouts/content/default.marko
+++ b/sites/ironpros.com/server/components/layouts/content/default.marko
@@ -152,7 +152,7 @@ $ const displayInquiry = (content) => {
                   selector=bodyId
                   preventHTMLInjection=(!withAdInjection && !isSponsored)
                   mobile-leaderboard-ad-name="top-rotation-mobile"
-                  lazyload-first-image=lazyloadFirstImage
+                  lazyload-first-image=false
                 />
                 <if(content.transcript)>
                   $ const transcriptId = `content-transcript-${content.id}`;


### PR DESCRIPTION
Remove inclusions of gam, add height and width dimentions to company logos loading at the top of content pages & turn lazyloading of first image off to help prevent cls on mobile & desktop. 