### PR TITLE
Add section hero block

### DIFF
--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -2,6 +2,11 @@
   "<global-recommended-content-block>": {
     "template": "./recommended-content.marko"
   },
+  "<global-section-hero-block>": {
+    "template": "./section-hero.marko",
+    "@aliases": "array",
+    "@nodes": "array"
+  },
   "<global-page-details-block>": {
   "template": "./page-details.marko"
   },

--- a/packages/global/components/blocks/section-hero.marko
+++ b/packages/global/components/blocks/section-hero.marko
@@ -1,0 +1,52 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const aliases = getAsArray(input, 'aliases');
+$ const nodes = getAsArray(input, 'nodes');
+
+$ const heroNode = nodes.slice(0, 1)[0];
+$ const heroImageNode = {
+  id: heroNode.id,
+  type: heroNode.type,
+  siteContext: heroNode.siteContext,
+  primaryImage: heroNode.primaryImage,
+};
+$ const listNodes = nodes.slice(1);
+
+<div class="row">
+  <div class="col-lg-8">
+    <marko-web-element tag="h1" block-name="top-stories" name="header">
+      Top Story
+    </marko-web-element>
+    <marko-web-element block-name="top-story" name="row">
+      <marko-web-element block-name="top-story" name="col" modifiers=["hero"]>
+        <theme-content-node
+          image-position="top"
+          card=true
+          flush=true
+          image-only=true
+          modifiers=["top-story-hero-image"]
+          node=heroImageNode
+        >
+          <@image fluid=true width=685 ar="3:2" lazyload=false />
+        </theme-content-node>
+      </marko-web-element>
+      <marko-web-element block-name="top-story" name="col" modifiers=["list"]>
+        <theme-content-node
+          full-height=true
+          card=true
+          display-image=false
+          flush=true
+          with-dates=false
+          modifiers=["top-story-hero"]
+          node=heroNode
+        />
+      </marko-web-element>
+    </marko-web-element>
+  </div>
+  <div class="col-lg-4 page-rail">
+    <theme-latest-content-list-block nodes=listNodes title="Latest" >
+      <@native-x indexes=[0] name="default" aliases=aliases />
+    </theme-latest-content-list-block>
+    <!-- <global-video-player /> -->
+  </div>
+</div>

--- a/packages/global/components/layouts/website-section/default.marko
+++ b/packages/global/components/layouts/website-section/default.marko
@@ -1,7 +1,6 @@
 import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
 import { getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
-import clFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-list";
 
 $ const { GAM } = out.global;
 
@@ -31,37 +30,6 @@ $ const pageWrapperModifiers = defaultValue(input.pageWrapperModifiers, []);
       />
       $ const aliases = hierarchyAliases(section);
       <marko-web-page-wrapper modifiers=pageWrapperModifiers>
-        <if(withAds)>
-          <@section modifiers=["first-sm"]>
-            <theme-gam-define-display-ad
-              name="top-leaderboard"
-              position="section-page"
-              aliases=aliases
-              modifiers=[]
-            />
-          </@section>
-          <@section>
-            <marko-web-query|{ nodes }|
-              name="all-published-content"
-              params={
-                limit: 4,
-                queryFragment: clFragment,
-                requiresImage: true,
-                excludeContentTypes: ["Promotion", "Company", "TextAd"]
-              }
-            >
-              <theme-content-card-deck-block title="Recommended" nodes=nodes cols=4 />
-            </marko-web-query>
-          </@section>
-          <@section>
-            <theme-gam-define-display-ad
-              name="leaderboard"
-              position="section-page"
-              aliases=aliases
-              modifiers=[]
-            />
-          </@section>
-        </if>
         <for|s| of=sections>
           <@section|{ blockName }| modifiers=s.modifiers>
             <${s.renderBody}

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -2,14 +2,14 @@ import convert from "@parameter1/base-cms-marko-web-native-x/utils/convert-story
 import { getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { pagination: p, nativeX: nxConfig, site } = out.global;
+$ const { pagination: p, nativeX: nxConfig, site, GAM } = out.global;
 
 $ const { id, alias, name, pageNode } = input;
 $ const withNativeX = nxConfig && nxConfig.enabled ? defaultValue(input.withNativeX, true) : false;
-$ const withFeedAds = defaultValue(input.withFeedAds, false);
+$ const withFeedAds = defaultValue(input.withFeedAds, true);
 $ const sections = getAsArray(input, "sections");
 $ const perPage = 12;
-$ const withAds = alias === "premium-content" ? false : defaultValue(input.withAds, true);
+$ const withAds = alias === "premium-content" || !GAM ? false : defaultValue(input.withAds, true);
 
 <global-website-section-default-layout
   id=id

--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -11,7 +11,6 @@ $ const { noRail, modifiers } = input;
 $ const path = input.path || input.alias || req.path;
 $ const withAds = GAM ? defaultValue(input.withAds, true) : false;
 $ const aboveTheFold = defaultValue(input.aboveTheFold, false);
-
 $ const queryName = input.queryName ? input.queryName : "website-scheduled-content";
 $ const queryParams = {
   queryFragment,
@@ -21,7 +20,7 @@ $ const queryParams = {
   }),
 };
 
-$ const chunkLengths = [3, 3, 3, 3];
+$ const chunkLengths = p.page === 1 ? [6, 3, 3] : [3, 3, 3, 3];
 $ const limit = chunkLengths.reduce((n, length) => (n + length), 0);
 $ const params = { ...queryParams, limit, skip };
 
@@ -34,42 +33,133 @@ $ const params = { ...queryParams, limit, skip };
   }, []);
 
   <if(input.rails && input.rails.length === 1)>
-    <div class="row">
-      <div class="col-lg-8">
-        <for|nodeGroup, index| of=nodeGroups>
-          $ const isLast = index === nodeGroups.length - 1;
-          $ const header = index === 0 ? input.header : null;
-          $ const adName = index === 0 ? input.adName || "top-rotation" : input.adName || "rotation";
-          $ const flowInput = (index === 0 && aboveTheFold) ? { ...input.flow, lazyload: false } : input.flow;
-          $ const nativeX = index === 0 ? input.nativeX : undefined;
-          <section-feed-flow
-            nodes=nodeGroup
-            header=header
-            modifiers=modifiers
-            node=input.node
-            node-list=input.nodeList
-            aliases=input.aliases
-            flow=flowInput
-            with-ads=withAds
-            ad-name=adName
-            native-x=nativeX
+    <if(withAds)>
+      <div class="row">
+        <div class="col-lg-12">
+          <theme-gam-define-display-ad
+            name="top-leaderboard"
+            position="section-page"
+            aliases=aliases
+            modifiers=[]
           />
-        </for>
-        <if(withPagination)>
-          <theme-section-feed-block|{ totalCount }| alias=input.alias query-name=queryName count-only=true>
-            <@query-params ...queryParams />
-            <theme-pagination-controls
-              per-page=limit
-              total-count=totalCount
-              path=path
+        </div>
+      </div>
+    </if>
+    <if(p.page === 1)>
+      <global-section-hero-block nodes=nodeGroups[0] aliases=aliases/>
+      <if(withAds)>
+        <theme-gam-define-display-ad
+          name="leaderboard"
+          position="section-page"
+          aliases=aliases
+          modifiers=[]
+        />
+      </if>
+      <div class="row">
+        <div class="col-lg-8">
+          $ const page1NodeGroups = nodeGroups.slice(1);
+          <for|nodeGroup, index| of=page1NodeGroups>
+            $ const isLast = index === page1NodeGroups.length - 1;
+            $ const header = index === 0 ? input.header : null;
+            $ const adName = index === 0 ? input.adName || "top-rotation" : input.adName || "rotation";
+            $ const flowInput = (index === 0 && aboveTheFold) ? { ...input.flow, lazyload: false } : input.flow;
+            $ const nativeX = index === 0 ? input.nativeX : undefined;
+            <section-feed-flow
+              nodes=nodeGroup
+              modifiers=modifiers
+              node=input.node
+              node-list=input.nodeList
+              aliases=input.aliases
+              flow=flowInput
+              with-ads=(!isLast && withAds)
+              ad-name=adName
+              native-x=nativeX
+            >
+              <if(index === 0)>
+                <@header>
+                  More In
+                </@header>
+              </if>
+            </section-feed-flow>
+          </for>
+          <if(withPagination)>
+            <theme-section-feed-block|{ totalCount }| alias=input.alias query-name=queryName count-only=true>
+              <@query-params ...queryParams />
+              <theme-pagination-controls
+                per-page=limit
+                total-count=totalCount
+                path=path
+              />
+            </theme-section-feed-block>
+          </if>
+        </div>
+        <div class="col-lg-4">
+          <${input.rails[0].renderBody} />
+        </div>
+      </div>
+      <if(withAds)>
+        <div class="row">
+          <div class="col-lg-12">
+            <theme-gam-define-display-ad
+              name="leaderboard"
+              position="section-page"
+              aliases=aliases
+              modifiers=[]
             />
-          </theme-section-feed-block>
-        </if>
+          </div>
+        </div>
+      </if>
+    </if>
+    <else>
+      <div class="row">
+        <div class="col-lg-8">
+          <for|nodeGroup, index| of=nodeGroups>
+            $ const isLast = index === nodeGroups.length - 1;
+            $ const header = index === 0 ? input.header : null;
+            $ const adName = index === 0 ? input.adName || "top-rotation" : input.adName || "rotation";
+            $ const flowInput = (index === 0 && aboveTheFold) ? { ...input.flow, lazyload: false } : input.flow;
+            $ const nativeX = index === 0 ? input.nativeX : undefined;
+            <section-feed-flow
+              nodes=nodeGroup
+              header=header
+              modifiers=modifiers
+              node=input.node
+              node-list=input.nodeList
+              aliases=input.aliases
+              flow=flowInput
+              with-ads=(!isLast && withAds)
+              ad-name=adName
+              native-x=nativeX
+            />
+          </for>
+          <if(withPagination)>
+            <theme-section-feed-block|{ totalCount }| alias=input.alias query-name=queryName count-only=true>
+              <@query-params ...queryParams />
+              <theme-pagination-controls
+                per-page=limit
+                total-count=totalCount
+                path=path
+              />
+            </theme-section-feed-block>
+          </if>
+        </div>
+        <div class="col-lg-4">
+          <${input.rails[0].renderBody} />
+        </div>
       </div>
-      <div class="col-lg-4">
-        <${input.rails[0].renderBody} />
-      </div>
-    </div>
+      <if(withAds)>
+        <div class="row">
+          <div class="col-lg-12">
+            <theme-gam-define-display-ad
+              name="leaderboard"
+              position="section-page"
+              aliases=aliases
+              modifiers=[]
+            />
+          </div>
+        </div>
+      </if>
+    </else>
   </if>
   <else-if(noRail)>
     <div class="row">


### PR DESCRIPTION
Adjust section page layouts on page one to display Leaderboard, hero card/list, leaderboard and 6 item section feed with right rail, then leaderboard.  Page #2 will load leaderboard standard section feed with right rail and leaderboard after that. 

<img width="460" alt="Screenshot 2024-07-22 at 2 34 01 PM" src="https://github.com/user-attachments/assets/74c595ae-ee8b-4602-9e1a-68206ada9fa9">

![page2](https://github.com/user-attachments/assets/499ec026-c7c8-4127-8cb1-a013b55ccb83)
