### PR TITLE
Add support for withAds && withFeedAds to section feed wrapper

### DIFF
--- a/packages/global/components/layouts/content/contact.marko
+++ b/packages/global/components/layouts/content/contact.marko
@@ -5,7 +5,8 @@ import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql
 $ const { id, type, pageNode, ...rest } = input;
 
 $ const { site, pagination: p, req, i18n } = out.global;
-$ const withFeedAds = defaultValue(input.withFeedAds, false);
+$ const withAds = false;
+$ const withFeedAds = false;
 $ const lang = site.config.lang || "en";
 $ const perPage = 12;
 
@@ -55,7 +56,7 @@ $ const perPage = 12;
       skip: p.skip({ perPage }),
       queryFragment,
     };
-    <global-section-feed-wrapper query-name="all-author-content" with-ads=withFeedAds query-params={ contactId: id } path=req.path>
+    <global-section-feed-wrapper query-name="all-author-content" with-ads=withAds with-feed-ads=withFeedAds query-params={ contactId: id } path=req.path>
       <@header>${latestTitle}</@header>
       <@rail>
         <theme-client-side-most-popular-list-block class="sticky-top" limit=5 />

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -6,8 +6,8 @@ $ const { id, type, pageNode } = input;
 $ const { site, GAM } = out.global;
 $ const showCompanySectionFilter = site.get("showCompanySectionFilters") || false;
 
-$ const withAds = defaultValue(input.withAds, true);
-$ const withFeedAds = withAds ? defaultValue(input.withFeedAds, true) : defaultValue(input.withFeedAds, false);
+$ const withAds = GAM ? defaultValue(input.withAds, true) : defaultValue(input.withAds, false);
+$ const withFeedAds = defaultValue(input.withFeedAds, false);
 $ const sections = getAsArray(input, "sections");
 $ const alias = get(input, "primarySection.alias");
 $ const loadMore = defaultValue(input.loadMore, true);
@@ -88,7 +88,7 @@ $ const fixedAdBottom = defaultValue(input.fixedAdBottom, true);
           <if(loadMore)>
             <marko-web-page-wrapper>
               <@section>
-                <global-section-feed-wrapper aliases=aliases alias=content.primarySection.alias with-ads=withFeedAds ad-name="rotation">
+                <global-section-feed-wrapper aliases=aliases alias=content.primarySection.alias with-ads=withAds with-feed-ads=withFeedAds ad-name="rotation">
                   <@header>More in ${content.primarySection.name}</@header>
                   <@query-params excludeContentIds=[content.id] />
                   <@native-x index=[1] name="premium-content" aliases=aliases sectionName="Premium Content" />

--- a/packages/global/components/layouts/website-section/contact-us.marko
+++ b/packages/global/components/layouts/website-section/contact-us.marko
@@ -2,14 +2,14 @@ import convert from "@parameter1/base-cms-marko-web-native-x/utils/convert-story
 import { getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { pagination: p, nativeX: nxConfig, site } = out.global;
+$ const { pagination: p, nativeX: nxConfig, site, GAM } = out.global;
 
 $ const { id, alias, name, pageNode } = input;
 $ const withNativeX = nxConfig && nxConfig.enabled ? defaultValue(input.withNativeX, true) : false;
+$ const withAds = GAM defaultValue(input.withAds, false);
 $ const withFeedAds = defaultValue(input.withFeedAds, false);
 $ const sections = getAsArray(input, "sections");
 $ const perPage = 24;
-$ const withAds = alias === "premium-content" ? false : defaultValue(input.withAds, true);
 
 <global-website-section-default-layout
   id=id
@@ -70,7 +70,8 @@ $ const withAds = alias === "premium-content" ? false : defaultValue(input.withA
         aliases=aliases
         alias=alias
         flow=input.feedFlow
-        with-ads=withFeedAds
+        with-feed-ads=withFeedAds
+        with-ads=withAds
         query-params=input.queryParams
         above-the-fold=true
         ad-name=input.adName

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -6,10 +6,10 @@ $ const { pagination: p, nativeX: nxConfig, site, GAM } = out.global;
 
 $ const { id, alias, name, pageNode } = input;
 $ const withNativeX = nxConfig && nxConfig.enabled ? defaultValue(input.withNativeX, true) : false;
-$ const withFeedAds = defaultValue(input.withFeedAds, true);
 $ const sections = getAsArray(input, "sections");
 $ const perPage = 12;
 $ const withAds = alias === "premium-content" || !GAM ? false : defaultValue(input.withAds, true);
+$ const withFeedAds = defaultValue(input.withFeedAds, false);
 
 <global-website-section-default-layout
   id=id
@@ -70,7 +70,8 @@ $ const withAds = alias === "premium-content" || !GAM ? false : defaultValue(inp
         aliases=aliases
         alias=alias
         flow=input.feedFlow
-        with-ads=withFeedAds
+        with-ads=withAds
+        with-feed-ads=withFeedAds
         query-params=input.queryParams
         above-the-fold=true
         ad-name=input.adName
@@ -112,7 +113,8 @@ $ const withAds = alias === "premium-content" || !GAM ? false : defaultValue(inp
         aliases=aliases
         alias=alias
         flow=input.feedFlow
-        with-ads=withFeedAds
+        with-ads=withAds
+        with-feed-ads=withFeedAds
         query-params=input.queryParams
         above-the-fold=true
         ad-name=input.adName

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -16,7 +16,9 @@ $ const withFeatured = defaultValue(input.withFeatured, true);
 $ const excludedSectionIds = [];
 $ const { GAM, apollo, i18n } = out.global;
 
+$ const withAds = GAM ? defaultValue(input.withAds, true) : defaultValue(input.withAds, false);
 $ const withFeedAds = defaultValue(input.withFeedAds, false);
+
 $ const latestTitle = defaultValue(input.latestTitle, "Latest News");
 $ const morePrefix = defaultValue(input.morePrefix, "More from");
 
@@ -149,7 +151,8 @@ $ const promise = homePageTopStoriesLoader(apollo, {
               alias=section.alias
               aliases=aliases
               with-pagination=false
-              with-ads=withFeedAds
+              with-ads=withAds
+              with-feed-ads=withFeedAds
               ad-name="rotation"
             >
               <@header>${i18n(morePrefix)} ${config.siteName()}</@header>

--- a/packages/global/components/layouts/website-section/upcoming-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-feed.marko
@@ -9,8 +9,8 @@ $ const wufooUserName = site.get("wufoo.userName");
 $ const wufooFormTitle = site.get(`wufoo.${alias}.title`) || 'Drop us a line!';
 $ const wufooFormHash = site.get(`wufoo.${alias}.hash`);
 
-$ const withAds = defaultValue(input.withAds, false);
-$ const withFeedAds = withAds ? defaultValue(input.withFeedAds, true) : defaultValue(input.withFeedAds, false);
+$ const withAds = GAM ? defaultValue(input.withAds, true) : defaultValue(input.withAds, false);
+$ const withFeedAds = defaultValue(input.withFeedAds, false);
 
 $ const now = Date.now();
 $ const queryParams = {
@@ -73,7 +73,7 @@ $ const perPage = 12;
       <marko-web-website-section-description obj=section />
     </else>
 
-    <global-section-feed-wrapper aliases=aliases alias=alias modifiers=["upcoming"] with-ads=withFeedAds>
+    <global-section-feed-wrapper aliases=aliases alias=alias modifiers=["upcoming"] with-ads=withAds with-feed-ads=withFeedAds>
       <@node ...input.node />
       <@query-params ...queryParams />
       <@rail>

--- a/packages/global/components/layouts/website-section/webinars-feed.marko
+++ b/packages/global/components/layouts/website-section/webinars-feed.marko
@@ -1,9 +1,10 @@
 import { getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { pagination: p, nativeX: nxConfig, site } = out.global;
+$ const { pagination: p, nativeX: nxConfig, site, GAM } = out.global;
 
 $ const { id, alias, name, pageNode } = input;
+$ const withAds = GAM ? defaultValue(input.withAds, true) : defaultValue(input.withAds, false);
 $ const withFeedAds = defaultValue(input.withFeedAds, false);
 
 $ const sections = getAsArray(input, "sections");
@@ -37,7 +38,7 @@ $ const archiveQueryParams = {
   alias=alias
   name=name
   page-node=pageNode
-  with-ads=input.withAds
+  with-ads=withAds
 >
   <@head>
     <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
@@ -114,7 +115,8 @@ $ const archiveQueryParams = {
       aliases=aliases
       alias=alias
       flow=input.feedFlow
-      with-ads=input.withFeedAds
+      with-ads=withAds
+      with-feed-ads=withFeedAds
       query-params=archiveQueryParams
       above-the-fold=true
       ad-name=input.adName

--- a/packages/global/components/wrappers/marko.json
+++ b/packages/global/components/wrappers/marko.json
@@ -10,6 +10,7 @@
     "@with-pagination": "boolean",
     "@modifiers": "array",
     "@with-ads": "boolean",
+    "@with-feed-ads": "boolean",
     "@ad-name": "string",
     "@alias": "string",
     "@header": "string",

--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -200,6 +200,18 @@ $ const params = { ...queryParams, limit, skip };
   <else>
     $ const topNodeGroups = nodeGroups.slice(0, 2);
     $ const bottomNodeGroups = nodeGroups.slice(2);
+    <if(withAds)>
+      <div class="row">
+        <div class="col-lg-12">
+          <theme-gam-define-display-ad
+            name="top-leaderboard"
+            position="section-page"
+            aliases=aliases
+            modifiers=[]
+          />
+        </div>
+      </div>
+    </if>
     <div class="row">
       <div class="col-lg-8">
         <for|nodeGroup, index| of=topNodeGroups>
@@ -283,5 +295,17 @@ $ const params = { ...queryParams, limit, skip };
         </else>
       </div>
     </div>
+    <if(withAds)>
+      <div class="row">
+        <div class="col-lg-12">
+          <theme-gam-define-display-ad
+            name="leaderboard"
+            position="section-page"
+            aliases=aliases
+            modifiers=[]
+          />
+        </div>
+      </div>
+    </if>
   </else>
 </marko-web-query>

--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -10,6 +10,7 @@ $ const skip = p.skip({ perPage });
 $ const { noRail, modifiers } = input;
 $ const path = input.path || input.alias || req.path;
 $ const withAds = GAM ? defaultValue(input.withAds, true) : false;
+$ const withFeedAds = GAM ? defaultValue(input.withFeedAds, false) : false;
 $ const aboveTheFold = defaultValue(input.aboveTheFold, false);
 $ const queryName = input.queryName ? input.queryName : "website-scheduled-content";
 $ const queryParams = {
@@ -71,7 +72,7 @@ $ const params = { ...queryParams, limit, skip };
               node-list=input.nodeList
               aliases=input.aliases
               flow=flowInput
-              with-ads=(!isLast && withAds)
+              with-ads=(!isLast && withFeedAds)
               ad-name=adName
               native-x=nativeX
             >
@@ -97,7 +98,7 @@ $ const params = { ...queryParams, limit, skip };
           <${input.rails[0].renderBody} />
         </div>
       </div>
-      <if(withAds)>
+      <if(GAM)>
         <div class="row">
           <div class="col-lg-12">
             <theme-gam-define-display-ad
@@ -127,7 +128,7 @@ $ const params = { ...queryParams, limit, skip };
               node-list=input.nodeList
               aliases=input.aliases
               flow=flowInput
-              with-ads=(!isLast && withAds)
+              with-ads=(!isLast && withFeedAds)
               ad-name=adName
               native-x=nativeX
             />
@@ -178,7 +179,7 @@ $ const params = { ...queryParams, limit, skip };
             node-list=input.nodeList
             aliases=input.aliases
             flow=flowInput
-            with-ads=withAds
+            with-ads=withFeedAds
             ad-name=adName
             native-x=nativeX
           />
@@ -213,7 +214,7 @@ $ const params = { ...queryParams, limit, skip };
             node=input.node
             node-list=input.nodeList
             aliases=input.aliases
-            with-ads=withAds
+            with-ads=withFeedAds
             ad-name=adName
             flow=flowInput
             native-x=nativeX
@@ -258,7 +259,7 @@ $ const params = { ...queryParams, limit, skip };
             node=input.node
             node-list=input.nodeList
             aliases=input.aliases
-            with-ads=(!isLast && withAds)
+            with-ads=(!isLast && withFeedAds)
             flow=input.flow
           />
         </for>

--- a/sites/ironpros.com/server/components/layouts/content/contact.marko
+++ b/sites/ironpros.com/server/components/layouts/content/contact.marko
@@ -4,7 +4,10 @@ import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql
 
 $ const { id, type, pageNode, ...rest } = input;
 
-$ const { site, pagination: p, req, i18n } = out.global;
+$ const { site, pagination: p, req, i18n, GAM } = out.global;
+$ const withAds = GAM ? defaultValue(input.withAds, true) : defaultValue(input.withAds, false);
+$ const withFeedAds = defaultValue(input.withFeedAds, false);
+
 $ const lang = site.config.lang || "en";
 $ const perPage = 12;
 
@@ -53,7 +56,13 @@ $ const perPage = 12;
       skip: p.skip({ perPage }),
       queryFragment,
     };
-    <global-section-feed-wrapper query-name="all-author-content" query-params={ contactId: id } path=req.path>
+    <global-section-feed-wrapper
+      query-name="all-author-content"
+      query-params={ contactId: id }
+      path=req.path
+      with-ads=withAds
+      with-feed-ads=withFeedAds
+    >
       <@header>${latestTitle}</@header>
       <@rail>
         <theme-client-side-most-popular-list-block class="sticky-top" />

--- a/sites/ironpros.com/server/components/layouts/content/wrapper.marko
+++ b/sites/ironpros.com/server/components/layouts/content/wrapper.marko
@@ -5,7 +5,8 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 $ const { id, type, pageNode } = input;
 $ const { site, GAM } = out.global;
 
-$ const withAds = defaultValue(input.withAds, true);
+$ const withAds = GAM ? defaultValue(input.withAds, true) : defaultValue(input.withAds, false);
+$ const withFeedAds = defaultValue(input.withFeedAds, false);
 $ const sections = getAsArray(input, "sections");
 $ const alias = get(input, "primarySection.alias");
 $ const loadMore = defaultValue(input.loadMore, true);
@@ -83,7 +84,13 @@ $ const loadMore = defaultValue(input.loadMore, true);
           <if(loadMore && psAlias !== "home")>
             <marko-web-page-wrapper>
               <@section>
-                <global-section-feed-wrapper aliases=aliases alias=psAlias ad-name="rotation">
+                <global-section-feed-wrapper
+                  aliases=aliases
+                  alias=psAlias
+                  ad-name="rotation"
+                  with-ads=withAds
+                  with-feed-ads=withFeedAds
+                >
                   <@header>More in ${content.primarySection.name}</@header>
                   <@query-params excludeContentIds=[content.id] />
                   <@native-x index=[1] name="premium-content" aliases=aliases sectionName="Premium Content" />

--- a/sites/ironpros.com/server/components/layouts/website-section/contact-us.marko
+++ b/sites/ironpros.com/server/components/layouts/website-section/contact-us.marko
@@ -2,13 +2,16 @@ import convert from "@parameter1/base-cms-marko-web-native-x/utils/convert-story
 import { getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { pagination: p, nativeX: nxConfig, site } = out.global;
+$ const { pagination: p, nativeX: nxConfig, site, GAM } = out.global;
+
+$ const withAds = GAM ? defaultValue(input.withAds, true) : defaultValue(input.withAds, false);
+$ const withFeedAds = defaultValue(input.withFeedAds, false);
 
 $ const { id, alias, name, pageNode } = input;
 $ const withNativeX = defaultValue(input.withNativeX, true);
 $ const sections = getAsArray(input, "sections");
 $ const perPage = 24;
-$ const withAds = false;
+
 
 <global-website-section-default-layout
   id=id
@@ -72,6 +75,8 @@ $ const withAds = false;
         query-params=input.queryParams
         above-the-fold=true
         ad-name=input.adName
+        with-ads=withAds
+        with-feed-ads=withFeedAds
       >
         <@node ...input.node />
         <@rail>

--- a/sites/ironpros.com/server/components/layouts/website-section/feed.marko
+++ b/sites/ironpros.com/server/components/layouts/website-section/feed.marko
@@ -33,7 +33,8 @@ $ const { id, alias, name, pageNode } = input;
 $ const withNativeX = defaultValue(input.withNativeX, false);
 $ const sections = getAsArray(input, "sections");
 $ const perPage = 12;
-$ const withAds = !GAM || alias === "premium-content" ? false : defaultValue(input.withAds, false);
+$ const withAds = !GAM || alias === "premium-content" ? false : defaultValue(input.withAds, true);
+$ const withFeedAds = defaultValue(input.withFeedAds, false);
 
 <site-website-section-default-layout
   id=id
@@ -179,6 +180,7 @@ $ const withAds = !GAM || alias === "premium-content" ? false : defaultValue(inp
       alias=alias
       flow=input.feedFlow
       with-ads=withAds
+      with-feed-ads=withFeedAds
       query-params=input.queryParams
       above-the-fold=true
       ad-name=input.adName

--- a/sites/ironpros.com/server/components/layouts/website-section/webinars-feed.marko
+++ b/sites/ironpros.com/server/components/layouts/website-section/webinars-feed.marko
@@ -115,6 +115,8 @@ $ const archiveQueryParams = {
       query-params=archiveQueryParams
       above-the-fold=true
       ad-name=input.adName
+      with-ads=false
+      with-feed-ads=false
     >
       <@header>
         On Demand


### PR DESCRIPTION
Update calling layouts/wrappers and section feed wrapper compoonent to send with ads & with feed ads to be able to turn on wrapping leader board vs infeed ads.  with ads dictate wrapping leaderboards and withFeedAd are based of that given prop now.

### Section Page #1:

![fcp-1](https://github.com/user-attachments/assets/53d6b49d-d859-4ba2-8261-b57443c29c79)

### Section Page #2:
![fcp-2](https://github.com/user-attachments/assets/3172dd4d-b6e9-4c22-b53d-2c54d2c86ec8)

### Content Landing Page with load more:
![fcp-content](https://github.com/user-attachments/assets/10dbb98a-523f-4944-96d9-8dc33b7e3504)
