### PR TITLE
Adjust node chucks based on rail count & page#

### DIFF
--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -21,7 +21,8 @@ $ const queryParams = {
   }),
 };
 
-$ const chunkLengths = p.page === 1 ? [6, 3, 3] : [3, 3, 3, 3];
+<!-- only on page#1 and with single rail for now -->
+$ const chunkLengths = p.page === 1 && (input.rails && input.rails.length === 1) ? [6, 3, 3] : [3, 3, 3, 3];
 $ const limit = chunkLengths.reduce((n, length) => (n + length), 0);
 $ const params = { ...queryParams, limit, skip };
 


### PR DESCRIPTION
Only adjust the chucks if there is a single rail and the layout will change.  This will now acount for when multiple rails are passed in and need to have the full use of the 12 items to split into two seperate flows with individual rails.  Can revisit if the top needs to be adjusted on multi rail layouts. 

![ip](https://github.com/user-attachments/assets/4d9fd19d-bad0-45dc-8620-2d71be1720c5)

**VS**

![fcp-2](https://github.com/user-attachments/assets/5f00e266-23ac-4c10-a3d4-f8424ceba5d0)
