### PR TITLE
Add withPageHero prop and only enable on section feeds

### DIFF
--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -10,6 +10,7 @@ $ const sections = getAsArray(input, "sections");
 $ const perPage = 12;
 $ const withAds = alias === "premium-content" || !GAM ? false : defaultValue(input.withAds, true);
 $ const withFeedAds = defaultValue(input.withFeedAds, false);
+$ const withPageHero = defaultValue(input.withPageHero, true);
 
 <global-website-section-default-layout
   id=id
@@ -75,7 +76,9 @@ $ const withFeedAds = defaultValue(input.withFeedAds, false);
         query-params=input.queryParams
         above-the-fold=true
         ad-name=input.adName
+        with-page-hero=withPageHero
       >
+        <@header>More in ${section.name}</@header>
         <@node ...input.node />
         <if(withNativeX)>
           <@native-x index=[1] name="premium-content" aliases=aliases sectionName="Premium Content" />

--- a/packages/global/components/wrappers/marko.json
+++ b/packages/global/components/wrappers/marko.json
@@ -22,7 +22,8 @@
     "@node-list": "object",
     "@path": "string",
     "@above-the-fold": "boolean",
-    "@no-rail": "boolean"
+    "@no-rail": "boolean",
+    "@with-page-hero": "boolean"
   },
   "<global-native-x-section-feed-wrapper>": {
     "template": "./native-x-section-feed.marko"

--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -11,6 +11,7 @@ $ const { noRail, modifiers } = input;
 $ const path = input.path || input.alias || req.path;
 $ const withAds = GAM ? defaultValue(input.withAds, true) : false;
 $ const withFeedAds = GAM ? defaultValue(input.withFeedAds, false) : false;
+$ const withPageHero = defaultValue(input.withPageHero, false);
 $ const aboveTheFold = defaultValue(input.aboveTheFold, false);
 $ const queryName = input.queryName ? input.queryName : "website-scheduled-content";
 $ const queryParams = {
@@ -22,7 +23,7 @@ $ const queryParams = {
 };
 
 <!-- only on page#1 and with single rail for now -->
-$ const chunkLengths = p.page === 1 && (input.rails && input.rails.length === 1) ? [6, 3, 3] : [3, 3, 3, 3];
+$ const chunkLengths = withPageHero &&  p.page === 1 && (input.rails && input.rails.length === 1) ? [6, 3, 3] : [3, 3, 3, 3];
 $ const limit = chunkLengths.reduce((n, length) => (n + length), 0);
 $ const params = { ...queryParams, limit, skip };
 
@@ -47,7 +48,7 @@ $ const params = { ...queryParams, limit, skip };
         </div>
       </div>
     </if>
-    <if(p.page === 1)>
+    <if(p.page === 1 && withPageHero)>
       <global-section-hero-block nodes=nodeGroups[0] aliases=aliases/>
       <if(withAds)>
         <theme-gam-define-display-ad
@@ -68,6 +69,7 @@ $ const params = { ...queryParams, limit, skip };
             $ const nativeX = index === 0 ? input.nativeX : undefined;
             <section-feed-flow
               nodes=nodeGroup
+              header=header
               modifiers=modifiers
               node=input.node
               node-list=input.nodeList
@@ -76,13 +78,7 @@ $ const params = { ...queryParams, limit, skip };
               with-ads=(!isLast && withFeedAds)
               ad-name=adName
               native-x=nativeX
-            >
-              <if(index === 0)>
-                <@header>
-                  More In
-                </@header>
-              </if>
-            </section-feed-flow>
+           />
           </for>
           <if(withPagination)>
             <theme-section-feed-block|{ totalCount }| alias=input.alias query-name=queryName count-only=true>
@@ -99,18 +95,6 @@ $ const params = { ...queryParams, limit, skip };
           <${input.rails[0].renderBody} />
         </div>
       </div>
-      <if(GAM)>
-        <div class="row">
-          <div class="col-lg-12">
-            <theme-gam-define-display-ad
-              name="leaderboard"
-              position="section-page"
-              aliases=aliases
-              modifiers=[]
-            />
-          </div>
-        </div>
-      </if>
     </if>
     <else>
       <div class="row">
@@ -149,19 +133,19 @@ $ const params = { ...queryParams, limit, skip };
           <${input.rails[0].renderBody} />
         </div>
       </div>
-      <if(withAds)>
-        <div class="row">
-          <div class="col-lg-12">
-            <theme-gam-define-display-ad
-              name="leaderboard"
-              position="section-page"
-              aliases=aliases
-              modifiers=[]
-            />
-          </div>
-        </div>
-      </if>
     </else>
+    <if(withAds)>
+      <div class="row">
+        <div class="col-lg-12">
+          <theme-gam-define-display-ad
+            name="leaderboard"
+            position="section-page"
+            aliases=aliases
+            modifiers=[]
+          />
+        </div>
+      </div>
+    </if>
   </if>
   <else-if(noRail)>
     <div class="row">


### PR DESCRIPTION
By default it is set to false and only enabled withing the feeds layout by default.

### FCP sections: 
![fcp-section](https://github.com/user-attachments/assets/bf47ab50-2189-42ef-a524-08edc628a587)
### FCP content load more
<img width="1668" alt="Screenshot 2024-07-23 at 11 49 41 AM" src="https://github.com/user-attachments/assets/c82a76a4-1483-4c55-9e80-d971f997f854">

### IP content pages: 
<img width="2086" alt="Screenshot 2024-07-23 at 11 48 31 AM" src="https://github.com/user-attachments/assets/b3bf4d16-364b-4f6a-b57b-5511bb35932e">
