### PR TITLE
Remove duplicate leaderboard ad call on home page layout

### DIFF
--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -138,15 +138,6 @@ $ const promise = homePageTopStoriesLoader(apollo, {
           </@section>
 
           <@section>
-            <theme-gam-define-display-ad
-              name="leaderboard"
-              position="section-page"
-              aliases=aliases
-              modifiers=[]
-            />
-          </@section>
-
-          <@section>
             <global-section-feed-wrapper
               alias=section.alias
               aliases=aliases

--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -38,7 +38,7 @@ $ const params = { ...queryParams, limit, skip };
   <if(input.rails && input.rails.length === 1)>
     <if(withAds)>
       <div class="row">
-        <div class="col-lg-12">
+        <div class="col-lg-12 mb-block">
           <theme-gam-define-display-ad
             name="top-leaderboard"
             position="section-page"
@@ -51,12 +51,16 @@ $ const params = { ...queryParams, limit, skip };
     <if(p.page === 1 && withPageHero)>
       <global-section-hero-block nodes=nodeGroups[0] aliases=aliases/>
       <if(withAds)>
-        <theme-gam-define-display-ad
-          name="leaderboard"
-          position="section-page"
-          aliases=aliases
-          modifiers=[]
-        />
+        <div class="row">
+          <div class="col-lg-12 mb-block">
+            <theme-gam-define-display-ad
+              name="leaderboard"
+              position="section-page"
+              aliases=aliases
+              modifiers=[]
+            />
+          </div>
+        </div>
       </if>
       <div class="row">
         <div class="col-lg-8">
@@ -187,7 +191,7 @@ $ const params = { ...queryParams, limit, skip };
     $ const bottomNodeGroups = nodeGroups.slice(2);
     <if(withAds)>
       <div class="row">
-        <div class="col-lg-12">
+        <div class="col-lg-12 mb-block">
           <theme-gam-define-display-ad
             name="top-leaderboard"
             position="section-page"


### PR DESCRIPTION
This is now accounted for within the load more call directly like on other section feed calls

New version:
<img width="1497" alt="Screenshot 2024-07-23 at 1 13 14 PM" src="https://github.com/user-attachments/assets/332eb1ad-ed30-4b68-9e19-239c1e163126">

Staging:
<img width="1472" alt="Screenshot 2024-07-23 at 1 02 06 PM" src="https://github.com/user-attachments/assets/bc3c0b40-461e-4bfb-8ee4-b215c4b6b3f4">
