### PR TITLE
Add channel logos, adjust nave link colors & section :before border colors

### DIFF
--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -1,5 +1,5 @@
 import convert from "@parameter1/base-cms-marko-web-native-x/utils/convert-story-to-content";
-import { getAsArray } from "@parameter1/base-cms-object-path";
+import { get, getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { pagination: p, nativeX: nxConfig, site, GAM } = out.global;
@@ -31,12 +31,19 @@ $ const withPageHero = defaultValue(input.withPageHero, true);
   </@head>
 
   <@section|{ blockName, section, aliases }|>
-    <theme-website-section-breadcrumbs
-      section=section
-      display-home=false
-      display-self=false
-      modifiers=["website-section"]
-    />
+    $ const channel = getAsArray(section, "hierarchy")[0];
+    $ const { logo } = channel;
+
+    $ const useSectionLogos = get(site, "config.useSectionLogos");
+
+    <if(!logo || !useSectionLogos)>
+      <theme-website-section-breadcrumbs
+        section=section
+        display-home=false
+        display-self=false
+        modifiers=["website-section"]
+      />
+    </if>
 
     <if(input.beforeName)>
       <${input.beforeName}
@@ -46,10 +53,28 @@ $ const withPageHero = defaultValue(input.withPageHero, true);
       />
     </if>
 
-    <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
-      <if(p.page > 1)>${value}: Page ${p.page}</if>
-      <else>${value}</else>
-    </marko-web-website-section-name>
+    <div class="row website-section-header">
+      <if(logo && useSectionLogos)>
+        $ const obj = { ...logo, alt: `${channel.name} Logo` };
+        <marko-web-page-image
+          width=125
+          fluid=false
+          modifiers=["section-logo"]
+          ...input.image
+          obj=obj
+        />
+        <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section modifiers=[`${channel.alias}`]>
+          <if(p.page > 1)>${value}: Page ${p.page}</if>
+          <else>${value}</else>
+        </marko-web-website-section-name>
+      </if>
+      <else>
+        <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
+          <if(p.page > 1)>${value}: Page ${p.page}</if>
+          <else>${value}</else>
+        </marko-web-website-section-name>
+      </else>
+    </div>
 
     <if(input.afterName)>
       <${input.afterName}
@@ -78,7 +103,7 @@ $ const withPageHero = defaultValue(input.withPageHero, true);
         ad-name=input.adName
         with-page-hero=withPageHero
       >
-        <@header>More in ${section.name}</@header>
+        <!-- <@header>More in ${section.name}</@header> -->
         <@node ...input.node />
         <if(withNativeX)>
           <@native-x index=[1] name="premium-content" aliases=aliases sectionName="Premium Content" />

--- a/packages/global/components/layouts/website-section/marko.json
+++ b/packages/global/components/layouts/website-section/marko.json
@@ -58,6 +58,7 @@
     "@node": "object",
     "@with-ads": "boolean",
     "@with-native-x": "boolean",
+    "@with-page-hero": "boolean",
     "@query-params": "object"
   },
   "<global-website-section-webinars-feed-layout>": {

--- a/packages/global/graphql/fragments/website-section-page.js
+++ b/packages/global/graphql/fragments/website-section-page.js
@@ -1,0 +1,25 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment WebsiteSectionPageFragment on WebsiteSection {
+  id
+  alias
+  name
+  fullName
+  description
+  labels
+  hierarchy {
+    id
+    alias
+    name
+    logo {
+      id
+      src(input: { options: { auto: "format,compress" } })
+    }
+  }
+  logo {
+    id
+    src(input: { options: { auto: "format,compress" } })
+  }
+}
+`;

--- a/packages/global/templates/website-section/upcoming-events.marko
+++ b/packages/global/templates/website-section/upcoming-events.marko
@@ -19,4 +19,6 @@ $ const queryParams = {
   query-params=queryParams
   node={ withDates: true, withTeaser: true, withSection: false }
   with-native-x=false
+  with-ads=false
+  with-page-hero=false
 />

--- a/sites/forconstructionpros-global.com/config/site.js
+++ b/sites/forconstructionpros-global.com/config/site.js
@@ -54,6 +54,7 @@ module.exports = {
     },
     corporate: corporate.logo,
   },
+  useSectionLogos: true,
   tagline: ' ',
   socialMediaLinks: [
     { provider: 'facebook', href: 'https://www.facebook.com/ForConstructionPros', target: '_blank' },

--- a/sites/forconstructionpros-global.com/server/routes/website-section.js
+++ b/sites/forconstructionpros-global.com/server/routes/website-section.js
@@ -1,5 +1,5 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
-const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
+const queryFragment = require('@ac-business-media/package-global/graphql/fragments/website-section-page');
 const blogs = require('@ac-business-media/package-global/templates/website-section/blogs');
 const webinars = require('@ac-business-media/package-global/templates/website-section/webinars');
 const upcomingEvents = require('@ac-business-media/package-global/templates/website-section/upcoming-events');

--- a/sites/forconstructionpros-global.com/server/styles/index.scss
+++ b/sites/forconstructionpros-global.com/server/styles/index.scss
@@ -6,12 +6,15 @@ $theme-site-header-breakpoints: (
   small-text-secondary: 830px
 );
 
+
 // Colors
 $primary: #F26522;
 $secondary: #495057;
 $light: #e9ecef;
 $dark: #212529;
 $info: #6c757d;
+
+$skin-block-header-overline-color: $dark;
 
 @import "@ac-business-media/package-global/scss/core";
 
@@ -90,3 +93,63 @@ body .document-container > .page--spec-guide:first-of-type,
 body .document-container > .page--without-ads:first-of-type  {
   margin-top: 0;
 }
+// Site Section Colors
+$website-section-colors: (
+  equipment: #ffc20a,
+  trucks: #ffa200,
+  rental: #e72725,
+  concrete: #2483c6,
+  asphalt: #9acb3c,
+  pavement-maintenance: #f26522,
+  profit-matters: #e9a422,
+  equipment-management: #98002e,
+  ironpros: #c2933f,
+);
+
+/*! purgecss start ignore */
+/*! critical:start */
+
+.website-section-header {
+  align-items: center;
+  margin-bottom: 10px;
+  margin-left: 0;
+
+  & .page-image--section-logo {
+    width: 135px;
+    padding-right: 10px;
+    margin-bottom: 0;
+  }
+
+  & > .page-wrapper__website-section-name {
+    @media (max-width: 768px) {
+      font-size: 20px;
+    }
+    padding-left: 10px;
+    margin-bottom: 0;
+
+    border-left: solid $primary 4px;
+    @each $section, $color in $website-section-colors {
+      // page-wrapper__website-section-name--#54497
+      &--#{$section} {
+        border-left: solid $color 4px;
+      }
+    }
+  }
+}
+
+.site-navbar {
+  $self: &;
+  &--primary,
+  &--secondary {
+    @each $section, $color in $website-section-colors {
+      #{ $self } {
+        &__link[href*="#{$section}"]:hover,
+        &__link--active[href*="#{$section}"] {
+          color: $color;
+        }
+      }
+    }
+  }
+}
+/*! purgecss end ignore */
+/*! critical:end */


### PR DESCRIPTION
On channel feed pages display the channel logos as well as accounting for changing of the primary and secondary nave colors based on the related sections logo and color. 

<img width="1601" alt="Screenshot 2024-07-23 at 4 00 05 PM" src="https://github.com/user-attachments/assets/420cd69b-3833-49b0-8b7e-484d4b880b0e">
<img width="1664" alt="Screenshot 2024-07-23 at 4 00 17 PM" src="https://github.com/user-attachments/assets/755db499-b76e-48f5-87b6-c0a1ea06a060">
<img width="1755" alt="Screenshot 2024-07-23 at 4 00 27 PM" src="https://github.com/user-attachments/assets/aa0ebc2a-5e23-4f31-9870-d4aa40e2958c">
<img width="1687" alt="Screenshot 2024-07-23 at 4 00 38 PM" src="https://github.com/user-attachments/assets/fe2192d1-a04f-44d6-8a7c-061802cb828d">

<img width="1701" alt="Screenshot 2024-07-23 at 4 00 51 PM" src="https://github.com/user-attachments/assets/43612508-e29e-4ba3-b2c2-f6b7f1bafbd6">
