### PR TITLE
Adjust section layouts, legacy recommended block back & update header colors to be dark

### DIFF
--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -2,6 +2,9 @@
   "<global-recommended-content-block>": {
     "template": "./recommended-content.marko"
   },
+  "<global-recommended-block>": {
+    "template": "./recommended.marko"
+  },
   "<global-section-hero-block>": {
     "template": "./section-hero.marko",
     "@aliases": "array",

--- a/packages/global/components/blocks/recommended.marko
+++ b/packages/global/components/blocks/recommended.marko
@@ -1,0 +1,42 @@
+import { getAsObject, get } from "@parameter1/base-cms-object-path";
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-list";
+$ const { config } = out.global;
+
+// FCP and GIP
+$ const siteIds = ["53ca8d671784f8066eb2c949", "53c95fdd1784f8066eb2c891"];
+$ const useSectionAlias = siteIds.includes(get(config, 'websiteContext.id')) && input.sectionAlias;
+$ const sectionAlias =  useSectionAlias ? input.sectionAlias : "home"
+$ const limit = 4;
+$ const params = {
+  sectionAlias,
+  optionName: "Recommended",
+  limit,
+  skip: input.skip,
+  requiresImage: true,
+  ...(input.contentId && { excludeContentIds: [input.contentId] }),
+  queryFragment,
+};
+
+<marko-web-query|{ nodes }| name="website-scheduled-content" params=params collapsible=false>
+  <if(nodes.length === limit)>
+    <theme-content-card-deck-block cols=limit title="Recommended" nodes=nodes>
+      <@native-x ...getAsObject(input, "nativeX") />
+    </theme-content-card-deck-block>
+  </if>
+  <else>
+  $ const excludeContentIds = nodes.map((node) => node.id);
+  $ if (input.contentId) excludeContentIds.push(input.contentId);
+  $ const homeParams = {
+    ...params,
+    sectionAlias: "home",
+    limit: limit - nodes.length,
+    excludeContentIds
+  };
+  <marko-web-query|{ nodes: homeSectionNodes }| name="website-scheduled-content" params=homeParams>
+    $ nodes.push(...homeSectionNodes)
+    <theme-content-card-deck-block cols=limit title="Recommended" nodes=nodes>
+      <@native-x ...getAsObject(input, "nativeX") />
+    </theme-content-card-deck-block>
+  </marko-web-query>
+  </else>
+</marko-web-query>

--- a/packages/global/components/blocks/section-hero.marko
+++ b/packages/global/components/blocks/section-hero.marko
@@ -12,11 +12,8 @@ $ const heroImageNode = {
 };
 $ const listNodes = nodes.slice(1);
 
-<div class="row">
+<div class="row top-stories-row">
   <div class="col-lg-8">
-    <marko-web-element tag="h1" block-name="top-stories" name="header">
-      Top Story
-    </marko-web-element>
     <marko-web-element block-name="top-story" name="row">
       <marko-web-element block-name="top-story" name="col" modifiers=["hero"]>
         <theme-content-node
@@ -44,9 +41,8 @@ $ const listNodes = nodes.slice(1);
     </marko-web-element>
   </div>
   <div class="col-lg-4 page-rail">
-    <theme-latest-content-list-block nodes=listNodes title="Latest" >
+    <theme-latest-content-list-block nodes=listNodes title="">
       <@native-x indexes=[0] name="default" aliases=aliases />
     </theme-latest-content-list-block>
-    <!-- <global-video-player /> -->
   </div>
 </div>

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -18,9 +18,7 @@ $ const omedaConfig = site.get('omeda');
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
 
-    <marko-web-google-font family="Montserrat:ital,wght@0,400;0,500;0,600;0,700;1,400" />
-
-    <marko-web-google-font family="DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400" />
+    <marko-web-google-font family="Arimo:ital,wght@0,400;0,500;0,600;0,700;1,400?&display=swap" />
 
     <marko-web-deferred-script-loader-init />
 

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -18,7 +18,7 @@ $ const omedaConfig = site.get('omeda');
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
 
-    <marko-web-google-font family="Arimo:ital,wght@0,400;0,500;0,600;0,700;1,400?&display=swap" />
+    <marko-web-google-font family="Montserrat:ital,wght@0,400;0,500;0,600;0,700;1,400" />
 
     <marko-web-deferred-script-loader-init />
 

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -46,7 +46,7 @@ $ const fixedAdBottom = defaultValue(input.fixedAdBottom, true);
           <@section modifiers=["first-sm"]>
             <theme-gam-define-display-ad
               name="top-leaderboard"
-              position="section-page"
+              position="content-page"
               aliases=aliases
               modifiers=[]
             />
@@ -87,6 +87,16 @@ $ const fixedAdBottom = defaultValue(input.fixedAdBottom, true);
           $ const aliases = hierarchyAliases(section);
           <if(loadMore)>
             <marko-web-page-wrapper>
+              <if(withAds)>
+                <@section modifiers=["first-sm"]>
+                  <theme-gam-define-display-ad
+                    name="leaderboard"
+                    position="section-page"
+                    aliases=aliases
+                    modifiers=[]
+                  />
+                </@section>
+              </if>
               <@section>
                 <global-section-feed-wrapper aliases=aliases alias=content.primarySection.alias with-ads=withAds with-feed-ads=withFeedAds ad-name="rotation">
                   <@header>More in ${content.primarySection.name}</@header>

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -53,7 +53,7 @@ $ const withPageHero = defaultValue(input.withPageHero, true);
       />
     </if>
 
-    <div class="row website-section-header">
+    <div class="row website-section-header mb-block">
       <if(logo && useSectionLogos)>
         $ const obj = { ...logo, alt: `${channel.name} Logo` };
         <marko-web-page-image
@@ -88,9 +88,10 @@ $ const withPageHero = defaultValue(input.withPageHero, true);
     <if(pageDetails[alias])>
       <global-page-details-block content=pageDetails[alias] />
     </if>
-    <else>
+    <!-- <else>
       <marko-web-website-section-description obj=section />
-    </else>
+    </else> -->
+
     <if(alias !== "premium-content" || !nxConfig.domainName)>
       <global-section-feed-wrapper
         aliases=aliases

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -36,6 +36,19 @@ $ const withPageHero = defaultValue(input.withPageHero, true);
 
     $ const useSectionLogos = get(site, "config.useSectionLogos");
 
+    <if(withAds && p.page !== 1)>
+      <div class="row">
+        <div class="col-lg-12 mb-block">
+          <theme-gam-define-display-ad
+            name="top-leaderboard"
+            position="section-page"
+            aliases=aliases
+            modifiers=[]
+          />
+        </div>
+      </div>
+    </if>
+
     <if(!logo || !useSectionLogos)>
       <theme-website-section-breadcrumbs
         section=section

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -124,17 +124,9 @@ $ const promise = homePageTopStoriesLoader(apollo, {
           </@section>
 
           <@section>
-            <marko-web-query|{ nodes }|
-              name="all-published-content"
-              params={
-                limit: 4,
-                queryFragment: clFragment,
-                requiresImage: true,
-                excludeContentTypes: ["Promotion", "Company", "TextAd"]
-              }
-            >
-              <theme-content-card-deck-block title="Recommended" nodes=nodes cols=4 />
-            </marko-web-query>
+            <global-recommended-block section-alias=alias >
+              <@native-x indexes=[3] name="default" aliases=aliases />
+            </global-recommended-block>
           </@section>
 
           <@section>

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -129,7 +129,7 @@ $ const promise = homePageTopStoriesLoader(apollo, {
             </global-recommended-block>
           </@section>
 
-          <@section|{ aliases }| modifiers=["first-sm"]>
+          <@section|{ aliases }|>
             <theme-gam-define-display-ad
               name="leaderboard"
               position="section-page"

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -129,6 +129,14 @@ $ const promise = homePageTopStoriesLoader(apollo, {
             </global-recommended-block>
           </@section>
 
+          <@section|{ aliases }| modifiers=["first-sm"]>
+            <theme-gam-define-display-ad
+              name="leaderboard"
+              position="section-page"
+              aliases=aliases
+            />
+          </@section>
+
           <@section>
             <global-section-feed-wrapper
               alias=section.alias

--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -36,20 +36,23 @@ $ const params = { ...queryParams, limit, skip };
   }, []);
 
   <if(input.rails && input.rails.length === 1)>
-    <if(withAds)>
-      <div class="row">
-        <div class="col-lg-12 mb-block">
-          <theme-gam-define-display-ad
-            name="top-leaderboard"
-            position="section-page"
-            aliases=aliases
-            modifiers=[]
-          />
-        </div>
-      </div>
-    </if>
     <if(p.page === 1 && withPageHero)>
       <global-section-hero-block nodes=nodeGroups[0] aliases=aliases/>
+      <if(withAds)>
+        <div class="row">
+          <div class="col-lg-12 mb-block">
+            <theme-gam-define-display-ad
+              name="top-leaderboard"
+              position="section-page"
+              aliases=aliases
+              modifiers=[]
+            />
+          </div>
+        </div>
+      </if>
+      <global-recommended-block section-alias=input.alias >
+        <@native-x indexes=[3] name="default" aliases=aliases />
+      </global-recommended-block>
       <if(withAds)>
         <div class="row">
           <div class="col-lg-12 mb-block">
@@ -101,6 +104,18 @@ $ const params = { ...queryParams, limit, skip };
       </div>
     </if>
     <else>
+      <if(withAds)>
+        <div class="row">
+          <div class="col-lg-12 mb-block">
+            <theme-gam-define-display-ad
+              name="top-leaderboard"
+              position="section-page"
+              aliases=aliases
+              modifiers=[]
+            />
+          </div>
+        </div>
+      </if>
       <div class="row">
         <div class="col-lg-8">
           <for|nodeGroup, index| of=nodeGroups>

--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -104,18 +104,6 @@ $ const params = { ...queryParams, limit, skip };
       </div>
     </if>
     <else>
-      <if(withAds)>
-        <div class="row">
-          <div class="col-lg-12 mb-block">
-            <theme-gam-define-display-ad
-              name="top-leaderboard"
-              position="section-page"
-              aliases=aliases
-              modifiers=[]
-            />
-          </div>
-        </div>
-      </if>
       <div class="row">
         <div class="col-lg-8">
           <for|nodeGroup, index| of=nodeGroups>
@@ -204,18 +192,6 @@ $ const params = { ...queryParams, limit, skip };
   <else>
     $ const topNodeGroups = nodeGroups.slice(0, 2);
     $ const bottomNodeGroups = nodeGroups.slice(2);
-    <if(withAds)>
-      <div class="row">
-        <div class="col-lg-12 mb-block">
-          <theme-gam-define-display-ad
-            name="top-leaderboard"
-            position="section-page"
-            aliases=aliases
-            modifiers=[]
-          />
-        </div>
-      </div>
-    </if>
     <div class="row">
       <div class="col-lg-8">
         <for|nodeGroup, index| of=topNodeGroups>

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -17,15 +17,17 @@ $black: #141414 !default;
 $body-color: #141414;
 
 // Navbar
-$theme-site-navbar-primary-type: light !default;
-$theme-site-navbar-primary-link-color: #323239 !default;
+$theme-site-navbar-primary-type: dark !default;
+$theme-site-navbar-primary-link-color: #FFF !default;
 $theme-site-navbar-primary-link-active-color: $primary !default;
 $theme-site-navbar-primary-link-hover-color: $primary !default;
-$theme-site-navbar-primary-bg-color: #f0f1f2 !default;
+$theme-site-navbar-primary-bg-color: #000 !default;
 $theme-site-navbar-primary-font-size: 14px !default;
 $theme-site-navbar-primary-font-weight: 500 !default;
+$theme-site-navbar-secondary-type: dark !default;
+$theme-site-navbar-secondary-bg-color: #212121 !default;
 $theme-site-navbar-secondary-font-size: 14px !default;
-$theme-site-navbar-secondary-link-color: #0a0a0a !default;
+$theme-site-navbar-secondary-link-color: #fff !default;
 $theme-site-navbar-logo-height: 30px !default;
 
 

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -1,4 +1,4 @@
-@import "@parameter1/base-cms-marko-web/scss/fonts/arimo-fallback";
+@import "@parameter1/base-cms-marko-web/scss/fonts/montserrat-fallback";
 
 $marko-web-document-container-max-width: 1300px;
 $skin-content-body-max-width: 1000px !default;
@@ -6,8 +6,8 @@ $enable-rounded: true;
 $marko-web-page-wrapper-padding: 0;
 
 // Fonts
-$skin-font-family-primary: "Arimo", arimo-fallback, sans-serif !default;
-$skin-font-family-secondary: "Arimo", arimo-fallback, sans-serif !default;
+$skin-font-family-primary: "Montserrat", montserrat-fallback, sans-serif !default;
+$skin-font-family-secondary: "Montserrat", montserrat-fallback, sans-serif !default;
 
 
 $theme-content-body-font: $skin-font-family-primary !default;

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -1,4 +1,6 @@
-@import "@parameter1/base-cms-marko-web/scss/fonts/montserrat-fallback";
+@import "@parameter1/base-cms-marko-web/scss/fonts/arimo-fallback";
+
+@import url("https://fonts.googleapis.com/css?family=Arimo:400,400i,700&display=swap");
 
 $marko-web-document-container-max-width: 1300px;
 $skin-content-body-max-width: 1000px !default;
@@ -6,8 +8,8 @@ $enable-rounded: true;
 $marko-web-page-wrapper-padding: 0;
 
 // Fonts
-$skin-font-family-primary: "Montserrat", montserrat-fallback, sans-serif !default;
-$skin-font-family-secondary: "Montserrat", montserrat-fallback, sans-serif !default;
+$skin-font-family-primary: "Arimo", arimo-fallback, sans-serif !default;
+$skin-font-family-secondary: "Arimo", arimo-fallback, sans-serif !default;
 
 
 $theme-content-body-font: $skin-font-family-primary !default;

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -1,7 +1,5 @@
 @import "@parameter1/base-cms-marko-web/scss/fonts/arimo-fallback";
 
-@import url("https://fonts.googleapis.com/css?family=Arimo:400,400i,700&display=swap");
-
 $marko-web-document-container-max-width: 1300px;
 $skin-content-body-max-width: 1000px !default;
 $enable-rounded: true;

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -452,6 +452,21 @@ label {
   }
 }
 
+.site-navbar {
+  $self: &;
+  &--top {
+    #{ $self }__right {
+      .btn,
+      .site-navbar__toggler {
+        background-color: transparent;
+        svg {
+          fill: #fff;
+        }
+      }
+    }
+  }
+}
+
 .ad-container {
   $self: &;
   &--with-label>:first-child:before {

--- a/sites/forconstructionpros-global.com/config/site.js
+++ b/sites/forconstructionpros-global.com/config/site.js
@@ -41,10 +41,14 @@ module.exports = {
   },
   logos: {
     navbar: {
-      src: 'https://s3.amazonaws.com/media.base.parameter1.com/files/base/acbm/fcp/image/static/logo/FCP-logo-high-res.png?h=45&auto=format,compress',
+      src: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/site_logo.png?h=45&auto=format,compress',
       srcset: [
-        'https://s3.amazonaws.com/media.base.parameter1.com/files/base/acbm/fcp/image/static/logo/FCP-logo-high-res.png?h=90&auto=format,compress 2x',
+        'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/site_logo.png?h=90&auto=format,compress 2x',
       ],
+      // src: 'https://s3.amazonaws.com/media.base.parameter1.com/files/base/acbm/fcp/image/static/logo/FCP-logo-high-res.png?h=45&auto=format,compress',
+      // srcset: [
+      //   'https://s3.amazonaws.com/media.base.parameter1.com/files/base/acbm/fcp/image/static/logo/FCP-logo-high-res.png?h=90&auto=format,compress 2x',
+      // ],
     },
     footer: {
       src: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/static/logo/site_logo.png?h=45&auto=format,compress',


### PR DESCRIPTION
Adjust the section page layot to more closely resemble what they currently have & add recommended block with native ad call back to between featured nodes and list nodes on page #1 

Example with new header and fonts set to Arimo(current site font). 
![sectionPageWIthFOnts](https://github.com/user-attachments/assets/ae65ba25-4faa-4848-99a9-c9afc77e8bbf)


