### PR TITLE
Add passing of sapience to gamKeyValue targeting

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -1,5 +1,7 @@
 import createOmedaIdentityBuilder from "@parameter1/base-cms-marko-web-p1-events/utils/create-omeda-identity-builder";
 import { getAsObject } from "@parameter1/base-cms-object-path";
+import parseIdentityId from "../utils/parse-sapience-identity";
+
 
 $ const {
   site,
@@ -78,6 +80,9 @@ $ const omedaConfig = site.get('omeda');
       <marko-web-gam-enable>
         <@lazy-load ...site.getAsObject("gam.lazyLoad") />
       </marko-web-gam-enable>
+      $ const sapience = parseIdentityId(req);
+      $ const gamKeyValues = { uri: req.path, ...(sapience && { sapience }) };
+      <marko-web-gam-targeting key-values=gamKeyValues />
     </if>
   </@head>
   <@above-wrapper>

--- a/packages/global/utils/parse-sapience-identity.js
+++ b/packages/global/utils/parse-sapience-identity.js
@@ -1,0 +1,11 @@
+module.exports = (req) => {
+  const { __web_identity: cookie } = req.cookies;
+  if (!cookie) return null;
+  try {
+    const identity = JSON.parse(cookie);
+    if (identity && identity.id) return identity.id;
+    return null;
+  } catch (e) {
+    return null;
+  }
+};


### PR DESCRIPTION
Porting this from their current theme.  I am not sure of its usefullness still, but didn't want to leave it out if they where still using it. 

set the following cookie to get it to work

name: '__web_identity'

value: `{"id":"3437D8885012C7X"}`