### PR TITLE
Ensure RMI is displaying as expected and update content wrapper

### DIFF
--- a/packages/global/components/layouts/content/company.marko
+++ b/packages/global/components/layouts/content/company.marko
@@ -14,7 +14,9 @@ $ const lang = site.config.lang || "en";
 
 $ const displayInquiry = (content) => {
   if (site.get("inquiry.enabled") === false) return false;
-  return get(content, "company.enableRmi");
+  if (type === "company" && get(content, "enableRmi")) return true;
+  if (type === "product" && get(content, "company.enableRmi")) return true;
+  return false;
 }
 
 <global-content-wrapper-layout

--- a/packages/global/components/layouts/content/company.marko
+++ b/packages/global/components/layouts/content/company.marko
@@ -128,8 +128,8 @@ $ const displayInquiry = (content) => {
 
           <theme-latest-content-list-block
             query-name="all-company-content"
-            query-params={ companyId: id, includeContentTypes: ["Document", "Whitepaper"], withSite: false, limit: 5 }
-            title=`${i18n("Company Documents")}`
+            query-params={ companyId: id, includeContentTypes: ["Article", "Blog", "News"], withSite: false, limit: 5 }
+            title=`${i18n("Articles & News")}`
             with-native-x-section=false
             flush-x=false
             class="mt-block"
@@ -137,6 +137,27 @@ $ const displayInquiry = (content) => {
             <@node with-dates=false />
           </theme-latest-content-list-block>
 
+          <theme-latest-content-list-block
+            query-name="all-company-content"
+            query-params={ companyId: id, includeContentTypes: ["Product", "PressRelease"], withSite: false, limit: 5 }
+            title=`${i18n("Products & Press Releases")}`
+            with-native-x-section=false
+            flush-x=false
+            class="mt-block"
+          >
+            <@node with-dates=false />
+          </theme-latest-content-list-block>
+
+          <theme-latest-content-list-block
+            query-name="all-company-content"
+            query-params={ companyId: id, includeContentTypes: ["Video", "Whitepaper", "Webinar", "Document", "MediaGallery", "Podcast"], withSite: false, limit: 5 }
+            title=`${i18n("Videos & Resources")}`
+            with-native-x-section=false
+            flush-x=false
+            class="mt-block"
+          >
+            <@node with-dates=false />
+          </theme-latest-content-list-block>
 
           <${input.afterBody}
             aliases=aliases

--- a/packages/global/components/layouts/content/company.marko
+++ b/packages/global/components/layouts/content/company.marko
@@ -194,28 +194,21 @@ $ const displayInquiry = (content) => {
       </div>
 
       <div class="col-lg-4 pt-block">
-        <!-- $ const topCompany = aliases.includes("top-feed-companies"); -->
-        <theme-gam-define-display-ad
-          name="top-rotation"
-          position="content_page"
-          aliases=aliases
-          modifiers=["max-width-300", "center", "margin-auto-x", "rail"]
-          class="mb-0"
-        />
         $ const inquiry = site.getAsObject('inquiry');
         <if(displayInquiry(content))>
           <div class="mb-block">
             <theme-company-inquiry-form-block modifiers=["flush-x"] content=content consent-checkboxes=getAsArray(site, 'config.inquiry.consentCheckboxes') />
           </div>
         </if>
-
-        <theme-gam-define-display-ad
-          name="rotation-rail"
-          position="content_page"
-          aliases=aliases
-          modifiers=["max-width-300", "center", "margin-auto-x", "rail"]
-          class="mb-0"
-        />
+        <else-if(withAds && !isSponsored)>
+          <theme-gam-define-display-ad
+            name="top-rotation"
+            position="content_page"
+            aliases=aliases
+            modifiers=["max-width-300", "center", "margin-auto-x", "rail"]
+            class="mb-0"
+          />
+        </else-if>
       </div>
     </div>
   </@section>

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -124,16 +124,16 @@ $ const fixedAdBottom = defaultValue(input.fixedAdBottom, true);
               </@section>
             </marko-web-page-wrapper>
           </if>
+          <if(withAds && !isSponsored)>
+            <theme-reveal-ad-handler
+              select-all-targets=true
+              path=GAM.getAdUnit({ name: "reskin", aliases }).path
+              id="reveal-ad"
+            />
+            <theme-fixed-ad-bottom aliases=aliases />
+          </if>
         </marko-web-resolve-page>
       </marko-web-page-container>
-      <if(withAds && !isSponsored)>
-        <theme-reveal-ad-handler
-          select-all-targets=true
-          path=GAM.getAdUnit({ name: "reskin", aliases }).path
-          id="reveal-ad"
-        />
-        <theme-fixed-ad-bottom aliases=aliases />
-      </if>
     </if>
   </@below-page>
 </theme-content-page>

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -79,7 +79,7 @@ $ const fixedAdBottom = defaultValue(input.fixedAdBottom, true);
     </marko-web-resolve-page>
   </@page>
   <@below-page>
-    <if(type !== "page" && (loadMore || withAds))>
+    <if(type !== "page" && loadMore)>
       <marko-web-page-container for="content" tag="div" id=id type=type modifiers=["below"]>
         <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
           $ const section = content.primarySection;
@@ -124,16 +124,16 @@ $ const fixedAdBottom = defaultValue(input.fixedAdBottom, true);
               </@section>
             </marko-web-page-wrapper>
           </if>
-          <if(withAds && !isSponsored)>
-            <theme-reveal-ad-handler
-              select-all-targets=true
-              path=GAM.getAdUnit({ name: "reskin", aliases }).path
-              id="reveal-ad"
-            />
-            <theme-fixed-ad-bottom aliases=aliases />
-          </if>
         </marko-web-resolve-page>
       </marko-web-page-container>
+      <if(withAds && !isSponsored)>
+        <theme-reveal-ad-handler
+          select-all-targets=true
+          path=GAM.getAdUnit({ name: "reskin", aliases }).path
+          id="reveal-ad"
+        />
+        <theme-fixed-ad-bottom aliases=aliases />
+      </if>
     </if>
   </@below-page>
 </theme-content-page>


### PR DESCRIPTION
Move ad calls on content wrappers to be outside load more logic so they can be controlled independently.  Also update right rail if else to show RMI or top-rotation.  I also update the block calls on the company landing page to  match their current blocks, title and contenttTypes queries that is. 

![_fcpcompany-page](https://github.com/user-attachments/assets/548f7fe1-023d-499b-aaa4-e427a16becb9)

