### PR TITLE
Remove min-height:0 & add boarder back to top/bottom of Leaderboards

### DIFF
--- a/packages/global/scss/components/_ad-container.scss
+++ b/packages/global/scss/components/_ad-container.scss
@@ -60,17 +60,31 @@
       border-bottom: 2px solid $skin-ad-bg-color;
     }
   }
-  &--template-leaderboard, &--template-top-leaderboard {
-    min-height: 0;
-    // min-height: 20px + $leaderboard-min-height-mobile + $container-height;
-    // @media (min-width: 980px) {
-    //   min-height: 20px + $leaderboard-min-height-desktop + $container-height;
-    // }
-  }
+  // &--template-leaderboard, &--template-top-leaderboard {
+  //   min-height: 20px + $leaderboard-min-height-mobile + $container-height;
+  //   @media (min-width: 980px) {
+  //     min-height: 20px + $leaderboard-min-height-desktop + $container-height;
+  //   }
+  // }
   &--rail {
     background-color: #fff;
   }
   &--template-footer-leaderboard {
     border-top: 1px solid #f5f5fa;
+  }
+
+  &__wrapper {
+    #{ $self }__container {
+      position: relative;
+    }
+  }
+  &--template-leaderboard {
+    #{ $self }__wrapper {
+      margin-top: map-get($spacers, block);
+      padding-top: 15px;
+      padding-bottom: 20px;
+      border-top: 2px solid #ebebeb;
+      border-bottom: 2px solid #ebebeb;
+    }
   }
 }


### PR DESCRIPTION
This helps prevent cls, but I still need to adjust some stuff for that.  This is more so for adding the border top and bottom back aroud the lb ads on the page.

![_fcp-home](https://github.com/user-attachments/assets/cd08163f-b33f-4345-af10-7a795f368718)
![_fcp-section](https://github.com/user-attachments/assets/9f4916f5-8fef-4b38-8a33-849999c9b13d)

![content](https://github.com/user-attachments/assets/c0a97ec7-6fcc-4209-8253-1bedc2b68147)
