### PR TITLE
Prevent CLS with vue search input components at the top of content pages

### DIFF
--- a/packages/global/scss/components/_company-search.scss
+++ b/packages/global/scss/components/_company-search.scss
@@ -46,3 +46,10 @@
     }
   }
 }
+
+.company-section-search {
+ > div.col-md-6 {
+  // input height + wrapping style/elemetns
+  height: calc(1.5em + .75rem + 2px);
+ }
+}


### PR DESCRIPTION
Help prevent CLS with company search and caetegory search inputs at the top of content pages.