### PR TITLE
Add a site config for enabling contextual idx form gating

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -117,7 +117,6 @@ $ const loadMore = !showOverlay; // && !idxFormId;
               enabled=requiresRegistration
               required-access-level-ids=accessLevels
             >
-            $ console.log('enableContextualGating: ', enableContextualGating)
               <if(enableContextualGating && idxFormId)>
                 <if(displayIdxForm)>
                   $ const body = getContentPreview({ body: content.body, selector: "p:lt(3)" });

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -14,6 +14,7 @@ $ const {
   config,
 } = out.global;
 
+$ const enableContextualGating = defaultValue(site.enableContexturalGating, false);
 <!-- update contentIdxFormStateDisplayBase on the req cookies being present -->
 <!-- @todo figure out how to do this ahead of time within the content route if possible -->
 $ contentIdxFormState.displayForm = !Boolean(get(req, `cookies.${get(contentIdxFormState, 'cookie.name')}`));
@@ -116,7 +117,8 @@ $ const loadMore = !showOverlay; // && !idxFormId;
               enabled=requiresRegistration
               required-access-level-ids=accessLevels
             >
-              <if(idxFormId)>
+            $ console.log('enableContextualGating: ', enableContextualGating)
+              <if(enableContextualGating && idxFormId)>
                 <if(displayIdxForm)>
                   $ const body = getContentPreview({ body: content.body, selector: "p:lt(3)" });
                   <marko-web-content-body block-name=blockName obj={ body } />


### PR DESCRIPTION
For now just use a simple site config to enable/disable with the default being false.  I was looking into utilizing identityX config setups for this, but will revisit when a reevaluation of the full implementation is done. 