### PR TITLE
Update FCP navigation to keep topic at top and only switch out secondary

### DIFF
--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -30,6 +30,8 @@ $theme-site-navbar-secondary-font-size: 14px !default;
 $theme-site-navbar-secondary-link-color: #fff !default;
 $theme-site-navbar-logo-height: 30px !default;
 
+$theme-site-navbar-teriary-font-size: $theme-site-navbar-secondary-font-size !default;
+
 $theme-ad-box-shadow: 0 .125rem .25rem rgba($black, .075) !default;
 $theme-card-header-text-transform: uppercase !default;
 

--- a/packages/global/scss/components/_site-navbar-c.scss
+++ b/packages/global/scss/components/_site-navbar-c.scss
@@ -152,7 +152,7 @@
     padding-right: 20px;
   }
   &__items--tertiary, &__items--user, &__items--seller, &__items--magazine {
-    font-size: 13px;
+    font-size: $theme-site-navbar-teriary-font-size;
     margin-top: initial;
     display: flex;
     flex-direction: row;

--- a/sites/forconstructionpros-global.com/config/navigation.js
+++ b/sites/forconstructionpros-global.com/config/navigation.js
@@ -21,6 +21,7 @@ const secondary = [
   { href: '/directory', label: 'New Equipment Directory' },
   { href: 'https://ironpros.com', label: 'IRONPROS', target: '_blank' },
   { href: '/videos', label: 'Video Network' },
+  { href: '/magazine', label: 'Magazine' },
   { href: '/events', label: 'Events' },
   { href: '/podcasts', label: 'Podcasts' },
   { href: '/premium-content', label: 'Premium Content' },
@@ -73,17 +74,19 @@ const tertiaryItems = [
   {
     href: '/page/Subscribe-Links',
     label: 'Magazines',
-    // icon: 'book',
+    icon: 'book',
     forceLabel: true,
   },
-  // {
-  //   href: 'https://acbusiness.dragonforms.com/loading.do?omedasite=FCP_prefs_ProgReg',
-  //   label: 'FCP Mail',
-  //   icon: 'mail',
-  //   forceLabel: false,
-  //   target: '_blank',
-  // },
+  {
+    href: 'https://acbusiness.dragonforms.com/loading.do?omedasite=FCP_prefs_ProgReg',
+    label: 'Newsletters',
+    icon: 'mail',
+    forceLabel: true,
+    target: '_blank',
+  },
 ];
+
+const tertiary = { items: [...tertiaryItems, ...user.items] };
 
 module.exports = {
   type: 'navbar-c',
@@ -98,17 +101,17 @@ module.exports = {
   mobileMenu,
   topics,
   primary: {
-    items: topics,
-  },
-  secondary: {
     items: secondary,
   },
-  tertiary: { items: [...tertiaryItems, ...user.items] },
+  secondary: {
+    items: topics,
+  },
+  tertiary,
   contexts: [
     {
       when: ['/equipment', '/trucks'],
       secondary: { items: topics },
-      tertiary: { items: [] },
+      tertiary,
       primary: {
         items: [
           { href: '/trucks', label: 'Trucks' },
@@ -123,7 +126,7 @@ module.exports = {
     {
       when: ['/rental'],
       secondary: { items: topics },
-      tertiary: { items: [] },
+      tertiary,
       primary: {
         items: [
           { href: '/rental/construction', label: 'Construction' },
@@ -150,7 +153,7 @@ module.exports = {
     {
       when: ['/concrete'],
       secondary: { items: topics },
-      tertiary: { items: [] },
+      tertiary,
       primary: {
         items: [
           { href: '/concrete/decorative', label: 'Decorative' },
@@ -165,7 +168,7 @@ module.exports = {
     {
       when: ['/asphalt'],
       secondary: { items: topics },
-      tertiary: { items: [] },
+      tertiary,
       primary: {
         items: [
           { href: '/asphalt/additives', label: 'Additives' },
@@ -179,7 +182,7 @@ module.exports = {
     {
       when: ['/business'],
       secondary: { items: topics },
-      tertiary: { items: [] },
+      tertiary,
       primary: {
         items: [
           { href: '/business/business-services', label: 'Services' },
@@ -192,7 +195,7 @@ module.exports = {
     {
       when: ['/construction-technology'],
       secondary: { items: topics },
-      tertiary: { items: [] },
+      tertiary,
       primary: {
         items: [
           { href: '/construction-technology/apps', label: 'Apps' },
@@ -206,7 +209,7 @@ module.exports = {
     {
       when: ['/pavement-maintenance'],
       secondary: { items: topics },
-      tertiary: { items: [] },
+      tertiary,
       primary: {
         items: [
           { href: '/pavement-maintenance/sweepers', label: 'Sweepers' },
@@ -218,7 +221,7 @@ module.exports = {
     {
       when: ['/profit-matters'],
       secondary: { items: topics },
-      tertiary: { items: [] },
+      tertiary,
       primary: {
         items: [
           { href: '/profit-matters?contentTypes=Blog', label: 'Blogs' },

--- a/sites/forconstructionpros-global.com/server/styles/index.scss
+++ b/sites/forconstructionpros-global.com/server/styles/index.scss
@@ -15,6 +15,7 @@ $dark: #212529;
 $info: #6c757d;
 
 $skin-block-header-overline-color: $dark;
+$theme-site-navbar-secondary-font-size: 12px !default;
 
 @import "@ac-business-media/package-global/scss/core";
 
@@ -138,10 +139,11 @@ $website-section-colors: (
 }
 
 .site-navbar {
+  $self: &;
   &__logo {
     height: 45px;
   }
-  $self: &;
+
   &--primary,
   &--secondary {
     @each $section, $color in $website-section-colors {
@@ -151,6 +153,12 @@ $website-section-colors: (
           color: $color;
         }
       }
+    }
+  }
+
+  &__items--tertiary {
+    #{ $self }__link {
+      padding-right: 0
     }
   }
 }


### PR DESCRIPTION
Adjust loging to always keep topics in the primary and only switch out secondary.  Also adjust spacing on tertiary items as well as sizing for both secondary and teritiary nav items.  End result looking something like 

![Screenshot 2024-08-21 at 7 31 04 AM](https://github.com/user-attachments/assets/21ea36ab-1c51-46d2-8d77-47ec1d066d3e)
