### PR TITLE
Add consentPolicy prop support for idx inline & footer components

### DIFF
--- a/packages/global/components/blocks/newsletter-inline.marko
+++ b/packages/global/components/blocks/newsletter-inline.marko
@@ -54,7 +54,7 @@ $ const imageSrcset = withImage && imageSrc ? `${imageSrc}&dpr=2 2x` : null;
           loginEmailPlaceholder,
           loginEmailLabel: input.loginEmailLabel,
           actionText: input.actionText,
-          consentPolicy: input.consentPolicy || get(application, "organization.consentPolicy"),
+          consentPolicy: input.consentPolicy || identityX.config.get("consentPolicy") || get(application, "organization.consentPolicy"),
           emailConsentRequest: get(application, "organization.emailConsentRequest"),
           regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
           appContextId: identityX.config.get("appContextId"),

--- a/packages/global/components/site-footer/index.marko
+++ b/packages/global/components/site-footer/index.marko
@@ -42,7 +42,6 @@ $ const consentPolicy = (identityX) ? identityX.config.get("consentPolicy") : nu
       <div class="row">
         <marko-web-element block-name=blockName name="section" attrs={ "aria-label": "Newsletter Sign-Up Form Footer"}>
           <if(!newsletterConfig.disabled && useIdxNewsletterSignup)>
-            $ console.log(newsletterBlockProps, newsletterSignupConfigName)
             <identity-x-newsletter-form-footer config-name=newsletterSignupConfigName consent-policy=consentPolicy ...newsletterBlockProps />
           </if>
           <else-if(!newsletterConfig.disabled && newsletterConfig.action)>

--- a/packages/global/components/site-footer/index.marko
+++ b/packages/global/components/site-footer/index.marko
@@ -3,13 +3,15 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsObject } from "@parameter1/base-cms-object-path";
 import { asObject } from "@parameter1/base-cms-utils";
 
-$ const { config, site, i18n } = out.global;
+$ const { config, site, i18n, req } = out.global;
+$ const { identityX } = req;
 $ const newsletterSignupConfigName = defaultValue(input.newsletterSignupConfigName, "signupFooter");
 $ const newsletterBlockProps = getAsObject(input, "newsletterBlockProps");
 $ const newsletterConfig = site.getAsObject(`newsletter.${newsletterSignupConfigName}`);
 $ const blockName = input.blockName || "site-footer";
 $ const tagline = site.get("tagline");
 $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true);
+$ const consentPolicy = (identityX) ? identityX.config.get("consentPolicy") : null;
 
 <marko-web-block
   name=blockName
@@ -40,7 +42,8 @@ $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true
       <div class="row">
         <marko-web-element block-name=blockName name="section" attrs={ "aria-label": "Newsletter Sign-Up Form Footer"}>
           <if(!newsletterConfig.disabled && useIdxNewsletterSignup)>
-            <identity-x-newsletter-form-footer config-name=newsletterSignupConfigName ...newsletterBlockProps />
+            $ console.log(newsletterBlockProps, newsletterSignupConfigName)
+            <identity-x-newsletter-form-footer config-name=newsletterSignupConfigName consent-policy=consentPolicy ...newsletterBlockProps />
           </if>
           <else-if(!newsletterConfig.disabled && newsletterConfig.action)>
             <theme-newsletter-signup-banner-external-block

--- a/packages/global/config/identity-x.js
+++ b/packages/global/config/identity-x.js
@@ -22,6 +22,7 @@ module.exports = ({
     mobileNumber: 'Mobile Phone',
     organization: 'Company Name',
   },
+  consentPolicy = '<p class="mb-2">I accept that the data provided on this form will be processed, stored, and used in accordance with the terms set out in IRONMARKETS’ <a href="/page/privacy-policy" target="_blank">Privacy Policy</a>.</p>',
   ...rest
 } = {}) => {
   const config = new IdentityXConfiguration({
@@ -33,6 +34,7 @@ module.exports = ({
     gtmUserFields,
     defaultFieldLabels,
     onHookError: newrelic.noticeError.bind(newrelic),
+    consentPolicy,
     ...rest,
   });
   return config;


### PR DESCRIPTION
Add default org consentPolicy prop and utiliz it in the site footer and inline signup block compnenet to remove rev to mobile signup on simmple email forms.  This is currently how [WATT](https://github.com/parameter1/watt-global-media-websites/pull/348) has done it.

Inline form update
![Screenshot 2024-08-21 at 9 29 20 AM](https://github.com/user-attachments/assets/71135132-b84e-4568-a918-78e133b482aa)

both Profile & footer policies updated. 

![Screenshot 2024-08-21 at 9 31 59 AM](https://github.com/user-attachments/assets/4a473b26-ffb8-4a49-b651-02708f33d4fe)
