### PR TITLE
Fix sticky top offset & prevent CLS on non 970x250 leaderboards

### DIFF
--- a/packages/global/config/gam.js
+++ b/packages/global/config/gam.js
@@ -7,6 +7,7 @@ module.exports = ({
 } = {}) => {
   const config = new GAMConfiguration(accountId, { basePath });
   config.enabled = enabled;
+  config.showLabel = false;
   config.lazyLoad = {
     enabled: false, // set to true to enable lazy loading
     fetchMarginPercent: 200, // fetch ad when one viewport away

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -482,7 +482,6 @@ label {
     min-height: 157px;
     > #{ $self }__wrapper {
       min-height: 118px !important;
-      background-color: purple;
       > div {
         min-height: 90px;
       }

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -465,16 +465,40 @@ label {
 
 .ad-container {
   $self: &;
-  &--with-label>:first-child:before {
-    color: #91939c;
-    padding-bottom: 1rem;
-    font-size: 12px;
-    text-transform: none;
+  &--with-label {
+    >:first-child:before {
+      color: #91939c;
+      padding-bottom: 1rem;
+      font-size: 12px;
+      text-transform: none;
+    }
+    &#{ $self }--template-leaderboard {
+      min-height: 157px;
+      > #{ $self }__wrapper {
+        min-height: 118px !important;
+        > div {
+          min-height: 90px;
+        }
+      }
+    }
+    &--template-footer-leaderboard {
+      background: repeating-linear-gradient(-45deg,white,white 0.375rem,#f5f5fa 0.406rem,#f5f5fa 0.486rem);
+      border-bottom: 1px solid #f5f5fa;
+      padding-bottom: 30px;
+    }
   }
-  &--template-footer-leaderboard {
-    background: repeating-linear-gradient(-45deg,white,white 0.375rem,#f5f5fa 0.406rem,#f5f5fa 0.486rem);
-    border-bottom: 1px solid #f5f5fa;
-    padding-bottom: 30px;
+}
+
+// Added to prevent CLS in top leaderboard GAM was putting and inline style of display: none
+.page-wrapper__section--first-sm {
+  .ad-container {
+    &--with-label {
+      &.ad-container--template-leaderboard {
+        > .ad-container__wrapper {
+          display: flex !important;
+        }
+      }
+    }
   }
 }
 

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -472,31 +472,35 @@ label {
       font-size: 12px;
       text-transform: none;
     }
-    &#{ $self }--template-leaderboard {
-      min-height: 157px;
-      > #{ $self }__wrapper {
-        min-height: 118px !important;
-        > div {
-          min-height: 90px;
-        }
+  }
+  &#{ $self }--template-leaderboard {
+    > *:first-child {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    min-height: 157px;
+    > #{ $self }__wrapper {
+      min-height: 118px !important;
+      background-color: purple;
+      > div {
+        min-height: 90px;
       }
     }
-    &--template-footer-leaderboard {
-      background: repeating-linear-gradient(-45deg,white,white 0.375rem,#f5f5fa 0.406rem,#f5f5fa 0.486rem);
-      border-bottom: 1px solid #f5f5fa;
-      padding-bottom: 30px;
-    }
+  }
+  &--template-footer-leaderboard {
+    background: repeating-linear-gradient(-45deg,white,white 0.375rem,#f5f5fa 0.406rem,#f5f5fa 0.486rem);
+    border-bottom: 1px solid #f5f5fa;
+    padding-bottom: 30px;
   }
 }
 
 // Added to prevent CLS in top leaderboard GAM was putting and inline style of display: none
 .page-wrapper__section--first-sm {
   .ad-container {
-    &--with-label {
-      &.ad-container--template-leaderboard {
-        > .ad-container__wrapper {
-          display: flex !important;
-        }
+    &.ad-container--template-leaderboard {
+      > .ad-container__wrapper {
+        display: flex !important;
       }
     }
   }

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -465,21 +465,13 @@ label {
 
 .ad-container {
   $self: &;
-  &--with-label {
-    >:first-child:before {
-      color: #91939c;
-      padding-bottom: 1rem;
-      font-size: 12px;
-      text-transform: none;
-    }
-  }
   &#{ $self }--template-leaderboard {
     > *:first-child {
       display: flex;
       flex-direction: column;
       align-items: center;
     }
-    min-height: 157px;
+    min-height: 127px;
     > #{ $self }__wrapper {
       min-height: 118px !important;
       > div {
@@ -487,6 +479,29 @@ label {
       }
     }
   }
+  &--with-label {
+    >:first-child:before {
+      color: #91939c;
+      padding-bottom: 1rem;
+      font-size: 12px;
+      text-transform: none;
+    }
+    &#{ $self }--template-leaderboard {
+      > *:first-child {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+      min-height: 157px;
+      > #{ $self }__wrapper {
+        min-height: 118px !important;
+        > div {
+          min-height: 90px;
+        }
+      }
+    }
+  }
+
   &--template-footer-leaderboard {
     background: repeating-linear-gradient(-45deg,white,white 0.375rem,#f5f5fa 0.406rem,#f5f5fa 0.486rem);
     border-bottom: 1px solid #f5f5fa;
@@ -496,6 +511,28 @@ label {
 
 // Added to prevent CLS in top leaderboard GAM was putting and inline style of display: none
 .page-wrapper__section--first-sm {
+  &:first-of-type {
+    .ad-container {
+      &.ad-container--template-leaderboard {
+        min-height: 136px;
+        > .ad-container__wrapper {
+          min-height: 127px !important;
+        }
+        .ad-container__wrapper {
+          margin-top: 0;
+          padding-top: map-get($spacers, block);
+          border-top: none;
+        }
+        &.ad-container--with-label {
+          min-height: 140px;
+          .ad-container__wrapper {
+            padding-top: initial;
+            margin-top: map-get($spacers, block);
+          }
+        }
+      }
+    }
+  }
   .ad-container {
     &.ad-container--template-leaderboard {
       > .ad-container__wrapper {

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -394,6 +394,7 @@ label {
 }
 .sticky-top {
   z-index: initial;
+  top: 0;
 }
 /*! critical:end */
 


### PR DESCRIPTION
 - Remove top offset for sticky top class
 - Correct CLS issue caused by GAM adding/removing display: none style on the ad-container__wrapper div
 - Turn off `Advertisement` label. 


<img width="1631" alt="Screenshot 2024-08-22 at 2 15 39 PM" src="https://github.com/user-attachments/assets/c2fb026a-89ff-425a-8d78-b012956b04d4">

<img width="2047" alt="Screenshot 2024-08-22 at 2 16 52 PM" src="https://github.com/user-attachments/assets/18223f6d-b216-462b-b7cd-9049d7673923">


