### PR TITLE
Minor post launch adjustment for ad spacing & oid prop on omeda init for global

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -59,7 +59,7 @@ $ const omedaConfig = site.get('omeda');
 
     <!-- init omeda olytics -->
     <marko-web-omeda-olytics-init
-      oid="90d9e151682e4fdc8d57bf8d280bb1dd"
+      oid="c7c0f14368d64059acd58da1225ef510"
       on="load"
       request-frame=true
       target-tag="body"

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -6,7 +6,6 @@ $ const {
   req,
   nativeX,
   GAM,
-  contentMeterState,
 } = out.global;
 
 $ const omedaConfig = site.get('omeda');
@@ -110,15 +109,6 @@ $ const omedaConfig = site.get('omeda');
       </else>
       <global-site-menu has-user=hasUser reg-enabled=isEnabled />
     </marko-web-identity-x-context>
-    <if(contentMeterState && !contentMeterState.isLoggedIn)>
-      <theme-content-meter-block
-        views=contentMeterState.views
-        view-limit=contentMeterState.viewLimit
-        display-overlay=contentMeterState.displayOverlay
-        display-gate=contentMeterState.displayGate
-        dynamic-title="We hope you’ve enjoyed your articles."
-      />
-    </if>
     <marko-web-browser-component name="DynamicSiteMenuPositioner" />
     <${input.aboveContainer} />
   </@above-container>

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -3,7 +3,7 @@ import { getAsArray, get } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { id, type, pageNode } = input;
-$ const { site, GAM } = out.global;
+$ const { site, GAM, contentMeterState } = out.global;
 $ const showCompanySectionFilter = site.get("showCompanySectionFilters") || false;
 
 $ const withAds = GAM ? defaultValue(input.withAds, true) : defaultValue(input.withAds, false);
@@ -131,6 +131,15 @@ $ const fixedAdBottom = defaultValue(input.fixedAdBottom, true);
               id="reveal-ad"
             />
             <theme-fixed-ad-bottom aliases=aliases />
+            <if(contentMeterState && !contentMeterState.isLoggedIn)>
+              <theme-content-meter-block
+                views=contentMeterState.views
+                view-limit=contentMeterState.viewLimit
+                display-overlay=contentMeterState.displayOverlay
+                display-gate=contentMeterState.displayGate
+                dynamic-title="We hope you’ve enjoyed your articles."
+              />
+            </if>
           </if>
         </marko-web-resolve-page>
       </marko-web-page-container>

--- a/packages/global/scss/components/content-meter.scss
+++ b/packages/global/scss/components/content-meter.scss
@@ -143,3 +143,9 @@ $content-meter-mobile-breakpoint: 600px !default;
     }
   }
 }
+// account for fixed bottom leaderboard
+.marko-web-gam-fixed-ad-bottom--visible ~ .content-meter {
+  .content-meter__bar {
+    bottom: 90px;
+  }
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -394,7 +394,7 @@ label {
 }
 .sticky-top {
   z-index: initial;
-  top: 0;
+  top: map-get($spacers, block)
 }
 /*! critical:end */
 


### PR DESCRIPTION
 - Remove sticky top off set of 100 
 - fix spacing on fixed bottom ad and content menter sign up.
 - fix oid setting on omeda init 