### PR TITLE
Update to support displaying website image in 16:9 aspect ratio vs 3:2

### DIFF
--- a/packages/global/components/blocks/recommended-content.marko
+++ b/packages/global/components/blocks/recommended-content.marko
@@ -23,14 +23,14 @@ $ const title = defaultValue(input.title, "Recommended");
       >
         <theme-latest-content-list-block nodes=nodes title=customTitle query-params=input.queryParams class="recommended-content">
           <@native-x indexes=[0,2] name="default" aliases=input.aliases ...input.nativeX />
-          <@node with-section=true with-dates=false ...input.node />
+          <@node with-section=true with-dates=false image={ ar: "16:9" } ...input.node />
         </theme-latest-content-list-block>
       </marko-web-query>
     </if>
     <else>
       <theme-latest-content-list-block title="Recommended for You" query-params=input.queryParams class="recommended-content">
         <@native-x indexes=[0,2] name="default" aliases=input.aliases ...input.nativeX />
-        <@node with-section=true with-dates=false ...input.node />
+        <@node with-section=true with-dates=false image={ ar: "16:9" } ...input.node />
       </theme-latest-content-list-block>
     </else>
   </if>
@@ -46,7 +46,7 @@ $ const title = defaultValue(input.title, "Recommended");
     $ const queryParams = { ...input.queryParams, limit: 2 };
     <theme-latest-content-list-block title=customTitle query-params=queryParams class="recommended-content">
       <@native-x indexes=[0,2] name="default" aliases=input.aliases ...input.nativeX />
-      <@node with-section=true with-dates=false ...input.node />
+      <@node with-section=true with-dates=false image={ ar: "16:9" } ...input.node />
     </theme-latest-content-list-block>
 
   </else>

--- a/packages/global/components/blocks/recommended.marko
+++ b/packages/global/components/blocks/recommended.marko
@@ -18,6 +18,7 @@ $ const params = {
 <marko-web-query|{ nodes }| name="website-scheduled-content" params=params collapsible=false>
   <if(nodes.length === limit)>
     <theme-content-card-deck-block cols=limit title="Recommended" nodes=nodes with-native-x=true>
+      <@node image={ ar: "16:9" } ...input.node/>
       <@native-x ...getAsObject(input, "nativeX") />
     </theme-content-card-deck-block>
   </if>
@@ -33,6 +34,7 @@ $ const params = {
   <marko-web-query|{ nodes: homeSectionNodes }| name="website-scheduled-content" params=homeParams>
     $ nodes.push(...homeSectionNodes)
     <theme-content-card-deck-block cols=limit title="Recommended" nodes=nodes with-native-x=true>
+      <@node image={ ar: "16:9" } ...input.node />
       <@native-x ...getAsObject(input, "nativeX") />
     </theme-content-card-deck-block>
   </marko-web-query>

--- a/packages/global/components/blocks/section-hero.marko
+++ b/packages/global/components/blocks/section-hero.marko
@@ -24,7 +24,7 @@ $ const listNodes = nodes.slice(1);
           modifiers=["top-story-hero-image"]
           node=heroImageNode
         >
-          <@image fluid=true width=685 ar="3:2" lazyload=false />
+          <@image fluid=true width=685 ar="16:9" lazyload=false />
         </theme-content-node>
       </marko-web-element>
       <marko-web-element block-name="top-story" name="col" modifiers=["list"]>

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -74,7 +74,7 @@ $ const promise = homePageTopStoriesLoader(apollo, {
                         modifiers=["top-story-hero-image"]
                         node=heroImageNode
                       >
-                        <@image fluid=true width=685 ar="3:2" lazyload=false />
+                        <@image fluid=true width=685 ar="16:9" lazyload=false />
                       </theme-content-node>
                     </marko-web-element>
                     <marko-web-element block-name="top-story" name="col" modifiers=["list"]>
@@ -109,7 +109,7 @@ $ const promise = homePageTopStoriesLoader(apollo, {
                     query-params={ limit: 2, skip: 8 }
                     view-more=false
                   >
-                    <@node with-section=false />
+                    <@node with-section=false image={ ar: "16:9" } />
                   </theme-content-card-deck-block>
                 </div>
               </div>

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -23,7 +23,7 @@ $ const latestTitle = defaultValue(input.latestTitle, "Latest News");
 $ const morePrefix = defaultValue(input.morePrefix, "More from");
 
 $ const promise = homePageTopStoriesLoader(apollo, {
-  featuredParams: { limit: 7 },
+  featuredParams: { limit: 6 },
 });
 <marko-web-resolve|{ resolved: sectionContent }| promise=promise>
   $ const { topStory, featured, ids } = sectionContent;

--- a/packages/global/components/wrappers/components/section-feed-flow.marko
+++ b/packages/global/components/wrappers/components/section-feed-flow.marko
@@ -1,5 +1,5 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
-
+import { getAsArray } from "@parameter1/base-cms-object-path";
 $ const { nativeX: nxConfig } = out.global;
 
 $ const { nodes, nativeX } = input;
@@ -7,32 +7,35 @@ $ const { nodes, nativeX } = input;
 $ const lazyload = defaultValue(input.lazyload, true);
 $ const adName = defaultValue(input.adName, "rotation");
 $ const withNativeXSection = defaultValue(input.withNativeXSection, true);
+$ const modifiers = ["section-feed-mobile-cards", ...getAsArray(input, 'modifiers')];
+$ const imageOptions = defaultValue(input.imageOptions, { w: 240, h: 135, ar: "16:9" });
+$ const mobileImageOptions = defaultValue(input.mobileImageOptions, { w: 240, h: 135, ar: "16:9" });
 
 <if(nodes && nodes.length)>
   <if(nativeX && nativeX.index)>
     $ const nodesBefore = nodes.slice(0, nativeX.index);
     $ const nodesAfter = nodes.slice(nativeX.index);
-    <theme-section-feed-flow ...input.flow nodes=nodesBefore header=input.header modifiers=input.modifiers>
+    <theme-section-feed-flow ...input.flow nodes=nodesBefore header=input.header modifiers=modifiers>
       <@node-list inner-justified=false ...input.nodeList />
-      <@node with-dates=false with-section ...input.node />
+      <@node with-dates=false with-section image-options=imageOptions mobile-image-options=mobileImageOptions ...input.node />
     </theme-section-feed-flow>
     <marko-web-native-x-retrieve|{ wasFound, hasCampaign, campaign, linkAttrs, containerAttrs }| ...nxConfig.getPlacement({ name: nativeX.name, aliases: nativeX.aliases }) section-name=nativeX.sectionName>
       <if(wasFound && hasCampaign)>
-        <theme-section-feed-flow ...input.flow nodes=[campaign] modifiers=input.modifiers>
+        <theme-section-feed-flow ...input.flow nodes=[campaign] modifiers=modifiers>
           <@node-list inner-justified=false ...input.nodeList />
-          <@node with-dates=false with-section=true ...input.node container-attrs=containerAttrs link-attrs=linkAttrs />
+          <@node with-dates=false with-section=true image-options=imageOptions mobile-image-options=mobileImageOptions ...input.node container-attrs=containerAttrs link-attrs=linkAttrs />
         </theme-section-feed-flow>
       </if>
     </marko-web-native-x-retrieve>
-    <theme-section-feed-flow ...input.flow nodes=nodesAfter modifiers=input.modifiers>
+    <theme-section-feed-flow ...input.flow nodes=nodesAfter modifiers=modifiers>
       <@node-list inner-justified=false ...input.nodeList />
-      <@node with-dates=false with-section ...input.node />
+      <@node with-dates=false with-section image-options=imageOptions mobile-image-options=mobileImageOptions ...input.node />
     </theme-section-feed-flow>
   </if>
   <else>
-    <theme-section-feed-flow ...input.flow nodes=nodes header=input.header modifiers=input.modifiers>
+    <theme-section-feed-flow ...input.flow nodes=nodes header=input.header modifiers=modifiers>
       <@node-list inner-justified=false ...input.nodeList />
-      <@node with-dates=false with-section ...input.node />
+      <@node with-dates=false with-section image-options=imageOptions mobile-image-options=mobileImageOptions ...input.node />
     </theme-section-feed-flow>
   </else>
   <if(input.withAds)>

--- a/packages/global/components/wrappers/components/section-feed-flow.marko
+++ b/packages/global/components/wrappers/components/section-feed-flow.marko
@@ -1,15 +1,16 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsArray } from "@parameter1/base-cms-object-path";
-$ const { nativeX: nxConfig } = out.global;
+$ const { nativeX: nxConfig, site } = out.global;
 
 $ const { nodes, nativeX } = input;
-
+$ const defaultImageOption = site.getAsObject("sectionFeed.imageOptions");
+$ const defaultMobileImageOption = site.get("defaultAspectRatio") === "16:9" ? { w: 240, h: 135, ar: "16:9" } : {};
 $ const lazyload = defaultValue(input.lazyload, true);
 $ const adName = defaultValue(input.adName, "rotation");
 $ const withNativeXSection = defaultValue(input.withNativeXSection, true);
-$ const modifiers = ["section-feed-mobile-cards", ...getAsArray(input, 'modifiers')];
-$ const imageOptions = defaultValue(input.imageOptions, { w: 240, h: 135, ar: "16:9" });
-$ const mobileImageOptions = defaultValue(input.mobileImageOptions, { w: 240, h: 135, ar: "16:9" });
+$ const modifiers = [...site.getAsArray("sectionFeed.modifiers"), ...getAsArray(input, 'modifiers')];
+$ const imageOptions = defaultValue(input.imageOptions, defaultImageOption);
+$ const mobileImageOptions = defaultValue(input.mobileImageOptions, defaultMobileImageOption);
 
 <if(nodes && nodes.length)>
   <if(nativeX && nativeX.index)>

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -35,7 +35,7 @@
     "@parameter1/base-cms-marko-web-search": "^4.55.4",
     "@parameter1/base-cms-marko-web-social-sharing": "^4.55.4",
     "@parameter1/base-cms-marko-web-theme-default": "^4.40.3",
-    "@parameter1/base-cms-marko-web-theme-monorail": "^4.63.2",
+    "@parameter1/base-cms-marko-web-theme-monorail": "^4.64.0",
     "@parameter1/base-cms-marko-web-theme-monorail-magazine": "^4.60.2",
     "@parameter1/base-cms-object-path": "^4.40.3",
     "@parameter1/base-cms-utils": "^4.40.3",

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -16,6 +16,9 @@ $theme-header-font-family: $skin-font-family-primary !default;
 $black: #141414 !default;
 $body-color: #141414;
 
+$image-mobile-width: 100% !default;
+$image-mobile-height: initial !default;
+
 // Navbar
 $theme-site-navbar-primary-type: dark !default;
 $theme-site-navbar-primary-link-color: #FFF !default;

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -16,6 +16,7 @@ $theme-header-font-family: $skin-font-family-primary !default;
 $black: #141414 !default;
 $body-color: #141414;
 
+$image-desktop-height: 140px !default;
 $image-mobile-width: 100% !default;
 $image-mobile-height: initial !default;
 

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -15,7 +15,7 @@ $theme-header-font-family: $skin-font-family-primary !default;
 
 $black: #141414 !default;
 $body-color: #141414;
-
+$border-radius: 0 !default;
 $image-desktop-height: 140px !default;
 $image-mobile-width: 100% !default;
 $image-mobile-height: initial !default;

--- a/packages/global/scss/components/_node-list.scss
+++ b/packages/global/scss/components/_node-list.scss
@@ -15,8 +15,11 @@
     padding: 1.25rem;
     .section-feed-content-node--text-ad-content-type {
       background-color: $gray-100;
-      padding: 20px 0;
+      padding: 0 0 20px 0;
       margin: -20px 0;
+      .section-feed-content-node__contents {
+        padding: 0 20px;
+      }
     }
   }
   &--latest-issue {

--- a/packages/global/scss/components/_node-list.scss
+++ b/packages/global/scss/components/_node-list.scss
@@ -13,12 +13,6 @@
 
   &__node {
     padding: 1.25rem;
-    @media (min-width: 768px) {
-      .section-feed-content-node__image {
-        height: 139.5px;
-        width: 250px;
-      }
-    }
     .section-feed-content-node--text-ad-content-type {
       background-color: $gray-100;
       padding: 20px 0;

--- a/packages/global/scss/components/_node-list.scss
+++ b/packages/global/scss/components/_node-list.scss
@@ -13,12 +13,24 @@
 
   &__node {
     padding: 1.25rem;
+    @media (min-width: 768px) {
+      .section-feed-content-node__image {
+        height: 139.5px;
+        width: 250px;
+      }
+    }
     .section-feed-content-node--text-ad-content-type {
       background-color: $gray-100;
-      padding: 0 0 20px 0;
+      padding: 20px 0;
       margin: -20px 0;
-      .section-feed-content-node__contents {
-        padding: 0 20px;
+    }
+    @include media-breakpoint-down(sm) {
+      .section-feed-content-node--text-ad-content-type {
+        background-color: $gray-100;
+        padding: 0 0 20px 0;
+        .section-feed-content-node__contents {
+          padding: 0 20px;
+        }
       }
     }
   }

--- a/sites/forconstructionpros.com/config/site.js
+++ b/sites/forconstructionpros.com/config/site.js
@@ -15,6 +15,11 @@ module.exports = {
   // Module configs
   useLinkInjectedBody: process.env.USE_LINK_INJECTED_BODY || true,
   contentMeter,
+  sectionFeed: {
+    imageOptions: { w: 240, h: 135, ar: '16:9' },
+    mobileImageOptions: { w: 240, h: 135, ar: '16:9' },
+    modifiers: ['section-feed-mobile-cards'],
+  },
   gam,
   identityX,
   nativeX,

--- a/sites/forconstructionpros.com/package.json
+++ b/sites/forconstructionpros.com/package.json
@@ -40,7 +40,7 @@
     "@parameter1/base-cms-marko-web-gtm": "^4.60.2",
     "@parameter1/base-cms-marko-web-identity-x": "^4.61.0",
     "@parameter1/base-cms-marko-web-p1-events": "^4.63.2",
-    "@parameter1/base-cms-marko-web-theme-monorail": "^4.63.2",
+    "@parameter1/base-cms-marko-web-theme-monorail": "^4.64.0",
     "@parameter1/base-cms-object-path": "^4.40.3",
     "@parameter1/base-cms-utils": "^4.40.3",
     "@parameter1/base-cms-web-cli": "^4.57.1"

--- a/sites/ironpros.com/package.json
+++ b/sites/ironpros.com/package.json
@@ -44,7 +44,7 @@
     "@parameter1/base-cms-marko-web-search": "^4.55.4",
     "@parameter1/base-cms-marko-web-social-sharing": "^4.55.4",
     "@parameter1/base-cms-marko-web-theme-default": "^4.40.3",
-    "@parameter1/base-cms-marko-web-theme-monorail": "^4.63.2",
+    "@parameter1/base-cms-marko-web-theme-monorail": "^4.64.0",
     "@parameter1/base-cms-object-path": "^4.40.3",
     "@parameter1/base-cms-utils": "^4.40.3",
     "@parameter1/base-cms-web-cli": "^4.57.1",

--- a/sites/ironpros.com/server/styles/index.scss
+++ b/sites/ironpros.com/server/styles/index.scss
@@ -64,6 +64,10 @@ $theme-header-font-family: "integralcf-demibold", sans-serif !default;
 
 $theme-section-header-font: $theme-header-font-family;
 
+$image-desktop-height: 167px !default;
+$image-mobile-width: 112px !default;
+$image-mobile-height: 112px !default;
+
 @import "@ac-business-media/package-global/scss/core";
 
 .node-list .node-list__header,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,10 +1446,10 @@
     graphql-tag "^2.12.6"
     object-path "^0.11.8"
 
-"@parameter1/base-cms-marko-web-theme-monorail@^4.63.2":
-  version "4.63.2"
-  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-theme-monorail/-/base-cms-marko-web-theme-monorail-4.63.2.tgz#859ed165e2f6bb328a0273b4c6d272f252500062"
-  integrity sha512-+O0OIW64kL1oojc1K5VmQARolclZLQGFBTLj2OzIQFqQfb9d8aYa2h8pybWHVbyGuFEVSZdGaHmfi9I8mHgGUA==
+"@parameter1/base-cms-marko-web-theme-monorail@^4.64.0":
+  version "4.64.0"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-theme-monorail/-/base-cms-marko-web-theme-monorail-4.64.0.tgz#e786d5621bd4f0c2481f09e49f9af0f86ed61a7b"
+  integrity sha512-z+cryc2Kll8lOwuxtziI/QAFW3RXCRAL9wCSoGOsyD6Jk/b8MOwVyqUAxHCHptoawDde1JtQVtt5ZTdTjL5bsw==
   dependencies:
     "@parameter1/base-cms-dayjs" "^4.5.12"
     "@parameter1/base-cms-image" "^4.47.1"


### PR DESCRIPTION
~~@requires: [base-cms pr](https://github.com/parameter1/base-cms/pull/954) merged and deployed and deps upgrade for the css overrides to work.~~

Up for debate is also looking into a cleaner way to configuring or setting default 16:9 for all vs IronPros on sectionFeeds.  Instead of having to set site configs for all but IronPros.  At the moment it is done this way as the override for IronPros is {} && [] and if they are empty it gets crabby :( 

### FCP 16:9 
<img width="1358" alt="Screenshot 2024-08-27 at 10 23 08 AM" src="https://github.com/user-attachments/assets/db573e60-4331-4414-bcbe-32231dc52133">
<img width="499" alt="Screenshot 2024-08-27 at 11 22 08 AM" src="https://github.com/user-attachments/assets/1c6f693c-3eb1-4c6b-9cb7-e1416d1f6ef0">


### Not to mess with IronPros
<img width="1492" alt="Screenshot 2024-08-27 at 11 20 24 AM" src="https://github.com/user-attachments/assets/67187964-d291-4146-aecb-ac240844bb2b">


### Also not by setting the following you can also get this on FCP: 
**index.scss in site folder**
```scss
$image-mobile-width: 112px !default;
$image-mobile-height: 63px !default;
```
and this in the site config instead
```js
sectionFeed: {
    imageOptions: { w: 240, h: 135, ar: '16:9' },
    mobileImageOptions: { w: 240, h: 135, ar: '16:9' },
    modifiers: [],
  },
```
<img width="479" alt="Screenshot 2024-08-27 at 11 28 33 AM" src="https://github.com/user-attachments/assets/3aa123c2-5478-4448-ba71-ce0128e9ab11">
