### PR TITLE
Add missing items to mobile menu

### DIFF
--- a/sites/forconstructionpros.com/config/navigation.js
+++ b/sites/forconstructionpros.com/config/navigation.js
@@ -65,6 +65,11 @@ const mobileMenu = {
   ],
   secondary: [
     ...secondary,
+    { href: '/events', label: 'Events' },
+    { href: '/whitepapers', label: 'White Papers' },
+    { href: '/expert-columns', label: 'Expert Columns' },
+    { href: '/awards', label: 'Awards' },
+    { href: '/profit-matters', label: 'Profit Matters' },
     subscribe,
     { href: '/', label: 'Advertise', target: '_blank' },
   ],


### PR DESCRIPTION
 - Events
 - Whitepaper
 - Expert Insights
 - Awards
 - Profit Matters

Matched similar order to drop down but can vet with group

<img width="443" alt="Screenshot 2024-08-27 at 11 53 42 AM" src="https://github.com/user-attachments/assets/7724449f-c517-4ab7-b467-78e972ba9f29">
