### PR TITLE
Update fragment to include all required Parse.ly fields

### DIFF
--- a/packages/global/graphql/fragments/content-page.js
+++ b/packages/global/graphql/fragments/content-page.js
@@ -125,6 +125,19 @@ const factory = ({ useLinkInjectedBody = false, withMagazineSchedules = false } 
         alt
       }
     }
+    taxonomy {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+    siteContext {
+      url
+      path
+      canonicalUrl
+    }
     ...ContentPageFragment
   }
   ${monorailFragment}


### PR DESCRIPTION
Add missing content fields utilized withing the parse.ly components to determine path/url as well as send taxonomy withing the payload when present

New payload with corrected url/contextualPath stuff
```
{
  '@context': 'http://schema.org',
  '@type': 'NewsArticle',
  headline: 'Combating Construction Waste with Technology',
  url: 'https://www.forconstructionpros.com/equipment/material-processing-debris-handling/article/22889135/hover-combating-construction-waste-with-technology',
  thumbnailUrl: 'https://img.forconstructionpros.com/files/base/acbm/fcp/image/2024/03/AdobeStock_227054866_kavzov.65e777a70ba22.png?auto=format%2Ccompress&q=70',
  datePublished: '2024-04-09T06:29:00.000Z',
  articleSection: 'Material Processing & Debris Handling',
  creator: [ 'Kevin Sturm' ]
}
```