### PR TITLE
Adjust styling on company logos for FCP

### DIFF
--- a/packages/global/components/layouts/content/company-details/company-logo.marko
+++ b/packages/global/components/layouts/content/company-details/company-logo.marko
@@ -8,7 +8,7 @@ $ const blockName = "company-logo";
 $ const hasImage = Boolean(image.src);
 
 <if(hasImage)>
-  $ const src = buildImgixUrl(image.src, { w: 120, h: 80 });
+  $ const src = buildImgixUrl(image.src, { h: 50 });
   $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
   <marko-web-img
     src=src
@@ -16,6 +16,6 @@ $ const hasImage = Boolean(image.src);
     alt=image.alt
     class=`${blockName}__image`
     lazyload=true
-    attrs={ height: 80, width: 120 }
+    attrs={ height: 50 }
   />
 </if>

--- a/sites/ironpros.com/server/components/layouts/content/company-logo.marko
+++ b/sites/ironpros.com/server/components/layouts/content/company-logo.marko
@@ -1,0 +1,21 @@
+import { get, getAsObject } from "@parameter1/base-cms-object-path";
+import { buildImgixUrl } from "@parameter1/base-cms-image";
+
+$ const { content } = input;
+$ const image = getAsObject(content, "primaryImage");
+$ const blockName = "company-logo";
+
+$ const hasImage = Boolean(image.src);
+
+<if(hasImage)>
+  $ const src = buildImgixUrl(image.src, { w: 120, h: 80 });
+  $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
+  <marko-web-img
+    src=src
+    srcset=srcset
+    alt=image.alt
+    class=`${blockName}__image`
+    lazyload=true
+    attrs={ height: 80, width: 120 }
+  />
+</if>

--- a/sites/ironpros.com/server/components/layouts/content/company.marko
+++ b/sites/ironpros.com/server/components/layouts/content/company.marko
@@ -47,7 +47,7 @@ $ const displayInquiry = (content) => {
           <div class="col-md-9 col-sm-12 col-lg-10">
             <div class="ldp">
               <div class="ldp__logo">
-                <global-company-logo content=content />
+                <site-company-logo content=content />
               </div>
               <div class="ldp__title">
                 <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />

--- a/sites/ironpros.com/server/components/layouts/content/default.marko
+++ b/sites/ironpros.com/server/components/layouts/content/default.marko
@@ -50,7 +50,7 @@ $ const displayInquiry = (content) => {
           <div class="page-attribution__content-company-name">
             <if(company.primaryImage && company.primaryImage.src)>
               <marko-web-content-name tag="span" block-name="page-attribution" obj=company link=true>
-                <global-company-logo content=company />
+                <site-company-logo content=company />
               </marko-web-content-name>
             </if>
             <else>

--- a/sites/ironpros.com/server/components/layouts/content/marko.json
+++ b/sites/ironpros.com/server/components/layouts/content/marko.json
@@ -68,5 +68,9 @@
     "@page-node": "object",
     "@load-more": "boolean",
     "@with-ads": "boolean"
+  },
+  "<site-company-logo>": {
+    "template": "./company-logo.marko",
+    "@content": "object"
   }
 }

--- a/sites/ironpros.com/server/components/layouts/content/product.marko
+++ b/sites/ironpros.com/server/components/layouts/content/product.marko
@@ -33,7 +33,7 @@ $ const displayInquiry = (content) => {
         <div class="page-attribution__content-company-name">
           <if(company.primaryImage && company.primaryImage.src)>
             <marko-web-content-name tag="span" block-name="page-attribution" obj=company link=true>
-              <global-company-logo content=company />
+              <site-company-logo content=company />
             </marko-web-content-name>
           </if>
           <else>


### PR DESCRIPTION
FCP Prod:
<img width="1476" alt="Screenshot 2024-09-12 at 10 23 39 AM" src="https://github.com/user-attachments/assets/d9733a2f-8092-4016-81d2-3cb96eaae0f2">
FCP Dev:
<img width="1441" alt="Screenshot 2024-09-12 at 10 23 51 AM" src="https://github.com/user-attachments/assets/251e0ca9-5f49-4d03-b0be-aaae774e3df6">
IronPros Prod:
<img width="1715" alt="Screenshot 2024-09-12 at 10 24 04 AM" src="https://github.com/user-attachments/assets/440d3a99-cecb-4737-9bfc-a333413fdd2c">
IronPros Dev: (no change)
<img width="1698" alt="Screenshot 2024-09-12 at 10 24 17 AM" src="https://github.com/user-attachments/assets/e0609448-6a99-482a-a56e-90b1467c5248">
