### PR TITLE
Re-enable "desktop" bottom sticky leaderboard

### DIFF
--- a/packages/global/config/gam.js
+++ b/packages/global/config/gam.js
@@ -55,8 +55,7 @@ module.exports = ({
         [300, 50],
       ],
       sizeMapping: [
-        // { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
-        { viewport: [751, 0], size: [] },
+        { viewport: [980, 0], size: [[970, 90], [970, 66], [728, 90]] },
         { viewport: [750, 0], size: [728, 90] },
         { viewport: [320, 0], size: [[300, 50], [320, 50]] },
       ],


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/32d1f7d5-b371-4008-9f84-96ce1bd87e7e)
