### PR TITLE
Add primary image to whitepaper layout

### DIFF
--- a/packages/global/components/layouts/content/whitepaper.marko
+++ b/packages/global/components/layouts/content/whitepaper.marko
@@ -39,7 +39,7 @@ $ const withAds = !showOverlay;
       <div class="col-lg-8">
         <div class="content-page-body">
           <default-theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
-
+            <theme-primary-image-block obj=content.primaryImage />
             $ const bodyId = `content-body-${content.id}`;
             <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
             <theme-content-download obj=content>


### PR DESCRIPTION
PROD:
![Screenshot from 2024-09-19 11-00-31](https://github.com/user-attachments/assets/417759e5-60be-4815-aa54-09c403acb479)

DEV:
![image](https://github.com/user-attachments/assets/f032fac3-3604-4294-a723-7e71f5a1452b)
