### PR TITLE
Utilize global defined fragment with startDate and endDate returned

### DIFF
--- a/packages/global/graphql/fragments/home-page-top-stories.js
+++ b/packages/global/graphql/fragments/home-page-top-stories.js
@@ -1,0 +1,45 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment WebsiteContentListFragment on Content {
+  id
+  type
+  shortName
+  teaser(input: { useFallback: false, maxLength: null })
+  labels
+  siteContext {
+    path
+  }
+  published
+  primarySection {
+    id
+    name
+    fullName
+    canonicalPath
+  }
+  primaryImage {
+    id
+    src(input: { options: { auto: "format,compress" } })
+    alt
+    isLogo
+  }
+  ... on ContentPromotion {
+    linkText
+    linkUrl
+  }
+  ... on ContentContact {
+    title
+    phone
+    publicEmail
+  }
+  ... on ContentWebinar {
+    startDate
+  }
+  ... on ContentEvent {
+    startDate
+    endDate
+  }
+}
+
+`;

--- a/packages/global/loaders/home-page-top-stories.js
+++ b/packages/global/loaders/home-page-top-stories.js
@@ -1,5 +1,5 @@
 const { websiteScheduledContent } = require('@parameter1/base-cms-web-common/block-loaders');
-const defaultFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-list');
+const defaultFragment = require('../graphql/fragments/home-page-top-stories');
 
 const loadTopStoryContent = async (apolloClient, params = {}) => {
   const defaults = {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ddad348b-c2cd-49e7-8cfe-8f920050da24)

Previously this was returning starts and ends resulting in startDate not being defined which resulted in the component that loads whether or not it is upcoming or not to assume an effective value of starting at 0 (or always in the past), this corrects that to load the correct fields for Webinars and events and is the same fragment as previous otherwise.