### PR TITLE
Add missing sponsors back to webinars attributions & fix mobile image sizing

### DIFF
--- a/packages/global/components/layouts/content/webinar.marko
+++ b/packages/global/components/layouts/content/webinar.marko
@@ -26,13 +26,15 @@ $ const sections = getAsArray(input, "sections");
 
           <theme-content-attribution obj=content elements=["company"] />
 
-          <theme-page-dates|{ blockName }|>
-            <marko-web-content-starts tag="span" block-name=blockName obj=content />
-            <if(content.starts !== content.ends)>
-              <marko-web-content-ends tag="span" block-name=blockName obj=content />
-            </if>
-          </theme-page-dates>
-
+          <div class="page-attribution__wrapper">
+            <theme-page-dates|{ blockName }|>
+              <marko-web-content-starts tag="span" block-name=blockName obj=content />
+              <if(content.starts !== content.ends)>
+                <marko-web-content-ends tag="span" block-name=blockName obj=content />
+              </if>
+            </theme-page-dates>
+            <default-theme-content-attribution obj=content />
+          </div>
           <global-sponsored-section-logo alias=primarySection.alias modifiers=["content-page"] class="mt-3" />
         </div>
       </div>

--- a/packages/global/graphql/fragments/content-page.js
+++ b/packages/global/graphql/fragments/content-page.js
@@ -113,6 +113,22 @@ const factory = ({ useLinkInjectedBody = false, withMagazineSchedules = false } 
     ... on ContentProduct {
       downloadUrl
     }
+    ... on ContentWebinar {
+      linkUrl
+      startDate
+      transcript
+      sponsors {
+        edges {
+          node {
+            id
+            name
+            siteContext {
+              path
+            }
+          }
+        }
+      }
+    }
     company {
       id
       labels

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -647,6 +647,52 @@ label {
     }
   }
 }
+/*! critical:start|content.webinar */
+.page-attribution__wrapper {
+  display: flex;
+
+  .page-dates+.page-attribution {
+    border-left: 1px solid #000;
+    margin-left: .5rem;
+    padding-left: .5rem;
+  }
+
+  .page-attribution__content-sponsors {
+    &::before {
+      content: "Sponsored By: ";
+    }
+    .page-attribution__content-name:first-child:before {
+      content: "";
+    }
+  }
+
+
+  .page-attribution__content-authors {
+    &::before {
+      content: "By";
+    }
+  }
+  a {
+    color: $primary;
+  }
+
+  > div {
+    margin-left: .25rem;
+  }
+
+  > div:first-child {
+    margin-left: 0;
+  }
+
+  div:last-child {
+    margin-bottom: 0;
+  }
+
+  &:empty {
+    display: none;
+  }
+}
+/*! critical:end */
 
 /*! critical:start|website-section.webinars */
 .section-feed-content-node__body {

--- a/sites/forconstructionpros.com/config/site.js
+++ b/sites/forconstructionpros.com/config/site.js
@@ -145,6 +145,7 @@ module.exports = {
     54468, // Pavement Maintenance
   ],
   specGuides,
+  defaultAspectRatio: '16:9',
   mindful: {
     namespace: 'acbm/default',
   },


### PR DESCRIPTION
correctly set defaultAspectRatio to 16:9 in the site config:
<img width="705" alt="Screenshot 2024-10-11 at 9 33 00 AM" src="https://github.com/user-attachments/assets/e3e63f64-5ed1-41cf-bb87-f339eb89d985">

Added sponsores
<img width="1711" alt="Screenshot 2024-10-11 at 9 15 08 AM" src="https://github.com/user-attachments/assets/71a8e8de-b08e-4ce1-af6a-87912c6e658c">


