### PR TITLE
Include multiple authors when applicable on default global layout

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -56,6 +56,9 @@ $ const loadMore = !showOverlay && !idxFormId;
         <if(authors.length === 1)>
           <theme-author-published-node author=authors[0] content=content lazyload=false display-updated-date=false />
         </if>
+        <else-if(authors.length > 1)>
+          <theme-content-attribution obj=content elements=["authors"] />
+        </else-if>
       </if>
       <if(type === "event")>
         <default-theme-page-dates|{ blockName }|>


### PR DESCRIPTION
PRODUCTION:
![Screenshot from 2024-11-08 08-40-24](https://github.com/user-attachments/assets/4f19a80a-c531-416f-8388-0f0cebfa48b6)

DEVELOPMENT:
![Screenshot from 2024-11-08 08-40-29](https://github.com/user-attachments/assets/fba33f93-26ff-4dfd-884f-e9748f38de85)


Appears this was ported correctly to IronPros however never accounted for in the global package.